### PR TITLE
Remove error message on persons with multiple affiliations

### DIFF
--- a/cypress/integration/validation.js
+++ b/cypress/integration/validation.js
@@ -717,6 +717,33 @@ describe('Person validation', function() {
         cy.get('#errorMessage').should('have.text', '');
     });
 
+    it('accepts Person with multiple affiliations', function() {
+        cy.get('#codemetaText').then((elem) =>
+            elem.text(JSON.stringify({
+                "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
+                "@type": "SoftwareSourceCode",
+                "author": {
+                    "@type": "Person",
+                    "@id": "http://example.org/~jdoe",
+                    "name": "Jane Doe",
+                    "affiliation": [
+                        {
+                            "@type": "Organization",
+                            "@id": "http://example.org/",
+                        },
+                        {
+                            "@type": "Organization",
+                            "@id": "http://example.com/",
+                        },
+                    ]
+                }
+            }))
+        );
+        cy.get('#validateCodemeta').click();
+
+        cy.get('#errorMessage').should('have.text', '');
+    });
+
     it('errors on list with invalid Person at the beginning', function() {
         cy.get('#codemetaText').then((elem) =>
             elem.text(JSON.stringify({

--- a/js/validation/things.js
+++ b/js/validation/things.js
@@ -155,7 +155,7 @@ function validatePersons(fieldName, doc) {
 // Validates an Organization or an array of Organization
 function validateOrganizations(fieldName, doc) {
     return validateListOrSingle(fieldName, doc, (subdoc, inList) => {
-        return validateOrganization(fieldName, doc);
+        return validateOrganization(fieldName, subdoc);
     });
 }
 


### PR DESCRIPTION
eg. it errored with:

```
"affiliation" must be a Organization object or URI, not [{"@type":"Organization","@id":"http://example.org/"},{"@type":"Organization","@id":"http://example.com/"}]'
```

which is not true.

This will cause the field to be populated with
`[object Object],[object Object]` instead of the actual values, which we need to fix eventually, but at least it doesn't incorrectly imply arrays are forbidden by Codemeta (which causes confusion such as https://github.com/codemeta/codemeta/issues/307#issuecomment-1590838647)