### PR TITLE
Fix breakage of keyboard-less license selection

### DIFF
--- a/cypress/integration/basics.js
+++ b/cypress/integration/basics.js
@@ -82,6 +82,29 @@ describe('JSON Generation', function() {
                 "description": "This is a\ngreat piece of software",
         });
     });
+
+    it('works when choosing licenses without the keyboard', function() {
+        cy.get('#name').type('My Test Software');
+        cy.get('#description').type('This is a\ngreat piece of software');
+        cy.get('#dateCreated').type('2019-10-02');
+        cy.get('#datePublished').type('2020-01-01');
+        cy.get('#license').type('AGPL-3.0');
+        // no cy.get("#license").type('{enter}'); here
+        cy.get('#generateCodemeta').click();
+
+        cy.get("#license").should('have.value', '');
+        cy.get('#errorMessage').should('have.text', '');
+        cy.get('#codemetaText').then((elem) => JSON.parse(elem.text()))
+            .should('deep.equal', {
+                "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
+                "@type": "SoftwareSourceCode",
+                "license": "https://spdx.org/licenses/AGPL-3.0",
+                "dateCreated": "2019-10-02",
+                "datePublished": "2020-01-01",
+                "name": "My Test Software",
+                "description": "This is a\ngreat piece of software",
+        });
+    });
 });
 
 describe('JSON Import', function() {

--- a/js/dynamic_form.js
+++ b/js/dynamic_form.js
@@ -163,7 +163,7 @@ function fieldToLower(event) {
 
 function initCallbacks() {
     document.querySelector('#license')
-        .addEventListener('keyup', validateLicense);
+        .addEventListener('change', validateLicense);
 
     document.querySelector('#generateCodemeta')
         .addEventListener('click', generateCodemeta);


### PR DESCRIPTION
Broken by 768caabb0768cf79e975914a792e0f1eb98de078.

@KShivendu Do you remember why you made this change in https://github.com/codemeta/codemeta-generator/pull/15/commits/eada168ddf99bed1cded2fd5358d663816ebfd4c ?