### PR TITLE
Fix scope of fieldValidators

### DIFF
--- a/js/validation/things.js
+++ b/js/validation/things.js
@@ -83,7 +83,7 @@ function validateThing(parentFieldName, typeFieldValidators, doc) {
 
     for (expectedType in typeFieldValidators) {
         if (isCompactTypeEqual(documentType, expectedType)) {
-            fieldValidators = typeFieldValidators[expectedType];
+            var fieldValidators = typeFieldValidators[expectedType];
             return Object.entries(doc).every((entry) => {
                 var fieldName = entry[0];
                 var subdoc = entry[1];


### PR DESCRIPTION
Without this, it was used as a global variable, so if the affiliation of an author was validated before other fields of the author (eg. familyName) then after affiliation validation ended, fieldValidators remained set to the Organization fields while we were validating the author (a Person)