### PR TITLE
Refactor codemeta validation code

### DIFF
--- a/cypress/integration/validation.js
+++ b/cypress/integration/validation.js
@@ -651,7 +651,7 @@ describe('Person validation', function() {
         );
         cy.get('#validateCodemeta').click();
 
-        cy.get('#errorMessage').should('have.text', 'Unknown field "foo" in "author".');
+        cy.get('#errorMessage').should('have.text', 'Unknown field "foo".');
     });
 
     it('errors on Person with invalid field', function() {
@@ -857,7 +857,7 @@ describe('Organization validation', function() {
         );
         cy.get('#validateCodemeta').click();
 
-        cy.get('#errorMessage').should('have.text', 'Unknown field "foo" in "author".');
+        cy.get('#errorMessage').should('have.text', 'Unknown field "foo".');
     });
 
     it('errors on Organization with invalid field', function() {
@@ -1005,7 +1005,7 @@ describe('CreativeWork validation', function() {
         );
         cy.get('#validateCodemeta').click();
 
-        cy.get('#errorMessage').should('have.text', 'Unknown field "foo" in "isPartOf".');
+        cy.get('#errorMessage').should('have.text', 'Unknown field "foo".');
     });
 
     it('errors on CreativeWork with invalid field', function() {

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@ See top-level LICENSE file for more information
     <script src="./js/fields_data.js"></script>
     <script src="./js/dynamic_form.js"></script>
     <script src="./js/codemeta_generation.js"></script>
+    <script src="./js/validation/utils.js"></script>
     <script src="./js/validation/primitives.js"></script>
     <script src="./js/validation/things.js"></script>
     <script src="./js/validation/index.js"></script>

--- a/js/validation/index.js
+++ b/js/validation/index.js
@@ -12,16 +12,179 @@
  * that are easy to understand for users with no understanding of JSON-LD.
  */
 
+const softwareFieldValidators = {
+    "@id": validateUrl,
+    "id": validateUrl,
 
-function validateDocument(doc) {
-    if (!Array.isArray(doc) && typeof doc != 'object') {
+    "codeRepository": validateUrls,
+    "programmingLanguage": noValidation,
+    "runtimePlatform": validateTexts,
+    "targetProduct": noValidation, // TODO: validate SoftwareApplication
+    "applicationCategory": validateTextsOrUrls,
+    "applicationSubCategory": validateTextsOrUrls,
+    "downloadUrl": validateUrls,
+    "fileSize": validateText,  // TODO
+    "installUrl": validateUrls,
+    "memoryRequirements": validateTextsOrUrls,
+    "operatingSystem": validateTexts,
+    "permissions": validateTexts,
+    "processorRequirements": validateTexts,
+    "releaseNotes": validateTextsOrUrls,
+    "softwareHelp": validateCreativeWorks,
+    "softwareRequirements": noValidation, // TODO: validate SoftwareSourceCode
+    "softwareVersion": validateText, // TODO?
+    "storageRequirements": validateTextsOrUrls,
+    "supportingData": noValidation, // TODO
+    "author": validateActors,
+    "citation": validateCreativeWorks, // TODO
+    "contributor": validateActors,
+    "copyrightHolder": validateActors,
+    "copyrightYear": validateNumbers,
+    "creator": validateActors, // TODO: still in codemeta 2.0, but removed from master
+    "dateCreated": validateDate,
+    "dateModified": validateDate,
+    "datePublished": validateDate,
+    "editor": validatePersons,
+    "encoding": noValidation,
+    "fileFormat": validateTextsOrUrls,
+    "funder": validateActors, // TODO: may be other types
+    "keywords": validateTexts,
+    "license": validateCreativeWorks,
+    "producer": validateActors,
+    "provider": validateActors,
+    "publisher": validateActors,
+    "sponsor": validateActors,
+    "version": validateNumberOrText,
+    "isAccessibleForFree": validateBoolean,
+    "isSourceCodeOf": validateTextsOrUrls,
+    "isPartOf": validateCreativeWorks,
+    "hasPart": validateCreativeWorks,
+    "position": noValidation,
+    "identifier": noValidation, // TODO
+    "description": validateText,
+    "name": validateText,
+    "sameAs": validateUrls,
+    "url": validateUrls,
+    "relatedLink": validateUrls,
+    "review": validateReview,
+
+    "softwareSuggestions": noValidation, // TODO: validate SoftwareSourceCode
+    "maintainer": validateActors,
+    "contIntegration": validateUrls,
+    "continuousIntegration": validateUrls,
+    "buildInstructions": validateUrls,
+    "developmentStatus": validateText, // TODO: use only repostatus strings?
+    "embargoDate": validateDate,
+    "embargoEndDate": validateDate,
+    "funding": validateText,
+    "issueTracker": validateUrls,
+    "referencePublication": noValidation, // TODO?
+    "readme": validateUrls,
+};
+
+const creativeWorkFieldValidators = {
+    "@id": validateUrl,
+    "id": validateUrl,
+
+    "author": validateActors,
+    "citation": validateCreativeWorks, // TODO
+    "contributor": validateActors,
+    "copyrightHolder": validateActors,
+    "copyrightYear": validateNumbers,
+    "creator": validateActors, // TODO: still in codemeta 2.0, but removed from master
+    "dateCreated": validateDate,
+    "dateModified": validateDate,
+    "datePublished": validateDate,
+    "editor": validatePersons,
+    "encoding": noValidation,
+    "funder": validateActors, // TODO: may be other types
+    "keywords": validateTexts,
+    "license": validateCreativeWorks,
+    "producer": validateActors,
+    "provider": validateActors,
+    "publisher": validateActors,
+    "sponsor": validateActors,
+    "version": validateNumberOrText,
+    "isAccessibleForFree": validateBoolean,
+    "isPartOf": validateCreativeWorks,
+    "hasPart": validateCreativeWorks,
+    "position": noValidation,
+    "identifier": noValidation, // TODO
+    "description": validateText,
+    "name": validateText,
+    "sameAs": validateUrls,
+    "url": validateUrls,
+};
+
+const roleFieldValidators = {
+    "roleName": validateText,
+    "startDate": validateDate,
+    "endDate": validateDate,
+
+    "schema:author": validateActor
+};
+
+const personFieldValidators = {
+    "@id": validateUrl,
+    "id": validateUrl,
+
+    "givenName": validateText,
+    "familyName": validateText,
+    "email": validateText,
+    "affiliation": validateOrganizations,
+    "identifier": validateUrls,
+    "name": validateText,  // TODO: this is technically valid, but should be allowed here?
+    "url": validateUrls,
+};
+
+const organizationFieldValidators = {
+    "@id": validateUrl,
+    "id": validateUrl,
+
+    "email": validateText,
+    "identifier": validateUrls,
+    "name": validateText,
+    "address": validateText,
+    "sponsor": validateActors,
+    "funder": validateActors, // TODO: may be other types
+    "isPartOf": validateOrganizations,
+    "url": validateUrls,
+
+    // TODO: add more?
+};
+
+const reviewFieldValidators = {
+    "reviewAspect": validateText,
+    "reviewBody": validateText,
+}
+
+function switchCodemetaContext(codemetaJSON, contextUrl) {
+    const previousCodemetaContext = codemetaJSON["@context"];
+    codemetaJSON["@context"] = contextUrl;
+    return previousCodemetaContext;
+}
+
+async function validateTerms(codemetaJSON) {
+    try {
+        await jsonld.expand(codemetaJSON, { safe: true });
+    } catch (validationError) {
+        if (validationError.details.event.code === "invalid property") {
+            setError(`Unknown field "${validationError.details.event.details.property}".`);
+            return false;
+        }
+    }
+    return true;
+}
+
+function validateCodemetaJSON(codemetaJSON) {
+    if (!Array.isArray(codemetaJSON) && typeof codemetaJSON != 'object') {
         setError("Document must be an object (starting and ending with { and }), not ${typeof doc}.")
         return false;
     }
     // TODO: validate id/@id
 
     // TODO: check there is either type or @type but not both
-    var type = getDocumentType(doc);
+    var type = getDocumentType(codemetaJSON);
     if (type === undefined) {
         setError("Missing type (must be SoftwareSourceCode or SoftwareApplication).")
         return false;
@@ -32,42 +195,29 @@ function validateDocument(doc) {
         setError(`Wrong document type: must be "SoftwareSourceCode"/"SoftwareApplication", not ${JSON.stringify(type)}`)
         return false;
     }
-    else {
-        return Object.entries(doc).every((entry) => {
-            var fieldName = entry[0];
-            var subdoc = entry[1];
-            if (fieldName == "@context") {
-                // Was checked before
-                return true;
-            }
-            else if (fieldName == "type" || fieldName == "@type") {
-                // Was checked before
-                return true;
-            }
-            else if (isFieldFromOtherVersionToIgnore(fieldName)) {
-                // Do not check fields from other versions FIXME
-                return true;
-            }
-            else {
-                var validator = softwareFieldValidators[fieldName];
-                if (validator === undefined) {
-                    // TODO: find if it's a field that belongs to another type,
-                    // and suggest that to the user
-                    setError(`Unknown field "${fieldName}".`)
-                    return false;
-                }
-                else {
-                    return validator(fieldName, subdoc);
-                }
-            }
-        });
-    }
+    return true;
 }
 
+function validateDocument(doc) {
+    return Object.entries(doc)
+        .filter(([fieldName]) => !isKeyword(fieldName))
+        .every(([fieldName, subdoc]) => {
+            const compactedFieldName = getCompactType(fieldName);
+            var validator = softwareFieldValidators[compactedFieldName];
+            if (validator === undefined) {
+                // TODO: find if it's a field that belongs to another type,
+                // and suggest that to the user
+                setError(`Unknown field "${compactedFieldName}".`)
+                return false;
+            } else {
+                return validator(compactedFieldName, subdoc);
+            }
+        });
+}
 
 async function parseAndValidateCodemeta(showPopup) {
     var codemetaText = document.querySelector('#codemetaText').innerText;
-    let parsed, doc;
+    let parsed;
 
     try {
         parsed = JSON.parse(codemetaText);
@@ -79,9 +229,20 @@ async function parseAndValidateCodemeta(showPopup) {
 
     setError("");
 
-    var isValid = validateDocument(parsed);
+    let isJSONValid = validateCodemetaJSON(parsed);
+
+    const previousCodemetaContext = switchCodemetaContext(parsed, INTERNAL_CONTEXT_URL);
+
+    let areTermsValid = await validateTerms(parsed);
+
+    const expanded = await jsonld.expand(parsed);
+    const doc = await jsonld.compact(expanded, INTERNAL_CONTEXT_URL);
+
+    switchCodemetaContext(parsed, previousCodemetaContext)
+
+    let isDocumentValid = validateDocument(doc);
     if (showPopup) {
-        if (isValid) {
+        if (isJSONValid && areTermsValid && isDocumentValid) {
             alert('Document is valid!')
         }
         else {
@@ -89,8 +250,5 @@ async function parseAndValidateCodemeta(showPopup) {
         }
     }
 
-    parsed["@context"] = LOCAL_CONTEXT_URL;
-    const expanded = await jsonld.expand(parsed);
-    doc = await jsonld.compact(expanded, LOCAL_CONTEXT_URL);
     return doc;
 }

--- a/js/validation/primitives.js
+++ b/js/validation/primitives.js
@@ -9,6 +9,10 @@
  * Validators for native schema.org data types.
  */
 
+function noValidation(fieldName, doc) {
+    return true;
+}
+
 // Validates an URL or an array of URLs
 function validateUrls(fieldName, doc) {
     return validateListOrSingle(fieldName, doc, (subdoc, inList) => {

--- a/js/validation/utils.js
+++ b/js/validation/utils.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2020-2021  The Software Heritage developers
+ * See the AUTHORS file at the top-level directory of this distribution
+ * License: GNU Affero General Public License version 3, or any later version
+ * See top-level LICENSE file for more information
+ */
+
+function getDocumentType(doc) {
+    // TODO: check there is at most one.
+    // FIXME: is the last variant allowed?
+    return doc["type"] || doc["@type"] || doc["codemeta:type"]
+}
+
+function getDocumentId(doc) {
+    return doc["id"] || doc["@id"];
+}
+
+function getCompactType(type) {
+    return type
+        .replace("schema:", "")
+        .replace("codemeta:", "");
+}
+
+function isCompactTypeEqual(type, compactedType) {
+    // FIXME: are all variants allowed?
+    return (type == `${compactedType}`
+        || type == `schema:${compactedType}`
+        || type == `codemeta:${compactedType}`
+        || type == `http://schema.org/${compactedType}`
+    );
+}
+
+function isKeyword(term) {
+    return ["@context", "type"].includes(term);
+}


### PR DESCRIPTION
Relates to #29.

This PR tries to improve the codemeta validation code, especially removing some hacks (e.g. coming from multi-version handling, like https://github.com/codemeta/codemeta-generator/pull/34/files/c2d17bd25f6924ea4a5fdab50a72250773b47d15#r1574302506).

After reviewing what's been done in other libraries (e.g. [codemetar](https://codemeta.github.io/codemetar/articles/C-validation-in-json-ld.html), [eossr](https://gitlab.com/escape-ossr/eossr/-/blob/master/eossr/metadata/codemeta.py), [caltech](https://github.com/caltechlibrary/convert_codemeta/blob/337e39338bcce4f0f201fe03500061ab14b2ae5c/convert_codemeta/validate.py)), I've noticed that:
1. There was no equivalent in terms of codemeta field by field validation.
2. These libraries validated the JSON version or the compacted version, or the framed version in the case of codemetar.

Thus, **validating the expanded version did not seem like the right way to do it** contrary to what was stated in #29, as it would introduce a lot of complexity to handle the complex structure of that version.

However, what I could think of to answer #29, was to compact the codemeta document into our internal context (which contains all the fields from all the versions, already used for multi-version generation) so that it becomes possible to validate a multi-version document without having to deal with any specific case.