### PR TITLE
Update SPDX licenses.json to 3.27.0

### DIFF
--- a/data/spdx/licenses.json
+++ b/data/spdx/licenses.json
@@ -1,23 +1,37 @@
 {
-  "licenseListVersion": "3.6-13-g75eedc1",
+  "licenseListVersion": "3.27.0",
   "licenses": [
     {
-      "reference": "./0BSD.html",
+      "reference": "https://spdx.org/licenses/0BSD.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/0BSD.json",
-      "referenceNumber": "223",
+      "detailsUrl": "https://spdx.org/licenses/0BSD.json",
+      "referenceNumber": 316,
       "name": "BSD Zero Clause License",
       "licenseId": "0BSD",
       "seeAlso": [
-        "http://landley.net/toybox/license.html"
+        "http://landley.net/toybox/license.html",
+        "https://opensource.org/licenses/0BSD"
       ],
       "isOsiApproved": true
     },
     {
-      "reference": "./AAL.html",
+      "reference": "https://spdx.org/licenses/3D-Slicer-1.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/AAL.json",
-      "referenceNumber": "54",
+      "detailsUrl": "https://spdx.org/licenses/3D-Slicer-1.0.json",
+      "referenceNumber": 61,
+      "name": "3D Slicer License v1.0",
+      "licenseId": "3D-Slicer-1.0",
+      "seeAlso": [
+        "https://slicer.org/LICENSE",
+        "https://github.com/Slicer/Slicer/blob/main/License.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/AAL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/AAL.json",
+      "referenceNumber": 424,
       "name": "Attribution Assurance License",
       "licenseId": "AAL",
       "seeAlso": [
@@ -26,290 +40,10 @@
       "isOsiApproved": true
     },
     {
-      "reference": "./ADSL.html",
+      "reference": "https://spdx.org/licenses/Abstyles.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/ADSL.json",
-      "referenceNumber": "202",
-      "name": "Amazon Digital Services License",
-      "licenseId": "ADSL",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/AmazonDigitalServicesLicense"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./AFL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/AFL-1.1.json",
-      "referenceNumber": "26",
-      "name": "Academic Free License v1.1",
-      "licenseId": "AFL-1.1",
-      "seeAlso": [
-        "http://opensource.linux-mirror.org/licenses/afl-1.1.txt",
-        "http://wayback.archive.org/web/20021004124254/http://www.opensource.org/licenses/academic.php"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./AFL-1.2.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/AFL-1.2.json",
-      "referenceNumber": "207",
-      "name": "Academic Free License v1.2",
-      "licenseId": "AFL-1.2",
-      "seeAlso": [
-        "http://opensource.linux-mirror.org/licenses/afl-1.2.txt",
-        "http://wayback.archive.org/web/20021204204652/http://www.opensource.org/licenses/academic.php"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./AFL-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/AFL-2.0.json",
-      "referenceNumber": "319",
-      "name": "Academic Free License v2.0",
-      "licenseId": "AFL-2.0",
-      "seeAlso": [
-        "http://wayback.archive.org/web/20060924134533/http://www.opensource.org/licenses/afl-2.0.txt"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./AFL-2.1.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/AFL-2.1.json",
-      "referenceNumber": "232",
-      "name": "Academic Free License v2.1",
-      "licenseId": "AFL-2.1",
-      "seeAlso": [
-        "http://opensource.linux-mirror.org/licenses/afl-2.1.txt"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./AFL-3.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/AFL-3.0.json",
-      "referenceNumber": "338",
-      "name": "Academic Free License v3.0",
-      "licenseId": "AFL-3.0",
-      "seeAlso": [
-        "http://www.rosenlaw.com/AFL3.0.htm",
-        "https://opensource.org/licenses/afl-3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./AGPL-1.0.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/AGPL-1.0.json",
-      "referenceNumber": "163",
-      "name": "Affero General Public License v1.0",
-      "licenseId": "AGPL-1.0",
-      "seeAlso": [
-        "http://www.affero.org/oagpl.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./AGPL-1.0-only.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/AGPL-1.0-only.json",
-      "referenceNumber": "64",
-      "name": "Affero General Public License v1.0 only",
-      "licenseId": "AGPL-1.0-only",
-      "seeAlso": [
-        "http://www.affero.org/oagpl.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./AGPL-1.0-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/AGPL-1.0-or-later.json",
-      "referenceNumber": "156",
-      "name": "Affero General Public License v1.0 or later",
-      "licenseId": "AGPL-1.0-or-later",
-      "seeAlso": [
-        "http://www.affero.org/oagpl.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./AGPL-3.0.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/AGPL-3.0.json",
-      "referenceNumber": "137",
-      "name": "GNU Affero General Public License v3.0",
-      "licenseId": "AGPL-3.0",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/agpl.txt",
-        "https://opensource.org/licenses/AGPL-3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./AGPL-3.0-only.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/AGPL-3.0-only.json",
-      "referenceNumber": "277",
-      "name": "GNU Affero General Public License v3.0 only",
-      "licenseId": "AGPL-3.0-only",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/agpl.txt",
-        "https://opensource.org/licenses/AGPL-3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./AGPL-3.0-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/AGPL-3.0-or-later.json",
-      "referenceNumber": "148",
-      "name": "GNU Affero General Public License v3.0 or later",
-      "licenseId": "AGPL-3.0-or-later",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/agpl.txt",
-        "https://opensource.org/licenses/AGPL-3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./AMDPLPA.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/AMDPLPA.json",
-      "referenceNumber": "122",
-      "name": "AMD\u0027s plpa_map.c License",
-      "licenseId": "AMDPLPA",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/AMD_plpa_map_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./AML.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/AML.json",
-      "referenceNumber": "145",
-      "name": "Apple MIT License",
-      "licenseId": "AML",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Apple_MIT_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./AMPAS.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/AMPAS.json",
-      "referenceNumber": "125",
-      "name": "Academy of Motion Picture Arts and Sciences BSD",
-      "licenseId": "AMPAS",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/BSD#AMPASBSD"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./ANTLR-PD.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/ANTLR-PD.json",
-      "referenceNumber": "41",
-      "name": "ANTLR Software Rights Notice",
-      "licenseId": "ANTLR-PD",
-      "seeAlso": [
-        "http://www.antlr2.org/license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./APAFML.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/APAFML.json",
-      "referenceNumber": "231",
-      "name": "Adobe Postscript AFM License",
-      "licenseId": "APAFML",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/AdobePostscriptAFM"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./APL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/APL-1.0.json",
-      "referenceNumber": "258",
-      "name": "Adaptive Public License 1.0",
-      "licenseId": "APL-1.0",
-      "seeAlso": [
-        "https://opensource.org/licenses/APL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./APSL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/APSL-1.0.json",
-      "referenceNumber": "363",
-      "name": "Apple Public Source License 1.0",
-      "licenseId": "APSL-1.0",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Apple_Public_Source_License_1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./APSL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/APSL-1.1.json",
-      "referenceNumber": "316",
-      "name": "Apple Public Source License 1.1",
-      "licenseId": "APSL-1.1",
-      "seeAlso": [
-        "http://www.opensource.apple.com/source/IOSerialFamily/IOSerialFamily-7/APPLE_LICENSE"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./APSL-1.2.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/APSL-1.2.json",
-      "referenceNumber": "187",
-      "name": "Apple Public Source License 1.2",
-      "licenseId": "APSL-1.2",
-      "seeAlso": [
-        "http://www.samurajdata.se/opensource/mirror/licenses/apsl.php"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./APSL-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/APSL-2.0.json",
-      "referenceNumber": "130",
-      "name": "Apple Public Source License 2.0",
-      "licenseId": "APSL-2.0",
-      "seeAlso": [
-        "http://www.opensource.apple.com/license/apsl/"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Abstyles.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Abstyles.json",
-      "referenceNumber": "67",
+      "detailsUrl": "https://spdx.org/licenses/Abstyles.json",
+      "referenceNumber": 252,
       "name": "Abstyles License",
       "licenseId": "Abstyles",
       "seeAlso": [
@@ -318,10 +52,24 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./Adobe-2006.html",
+      "reference": "https://spdx.org/licenses/AdaCore-doc.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Adobe-2006.json",
-      "referenceNumber": "288",
+      "detailsUrl": "https://spdx.org/licenses/AdaCore-doc.json",
+      "referenceNumber": 315,
+      "name": "AdaCore Doc License",
+      "licenseId": "AdaCore-doc",
+      "seeAlso": [
+        "https://github.com/AdaCore/xmlada/blob/master/docs/index.rst",
+        "https://github.com/AdaCore/gnatcoll-core/blob/master/docs/index.rst",
+        "https://github.com/AdaCore/gnatcoll-db/blob/master/docs/index.rst"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Adobe-2006.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Adobe-2006.json",
+      "referenceNumber": 658,
       "name": "Adobe Systems Incorporated Source Code License Agreement",
       "licenseId": "Adobe-2006",
       "seeAlso": [
@@ -330,10 +78,22 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./Adobe-Glyph.html",
+      "reference": "https://spdx.org/licenses/Adobe-Display-PostScript.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Adobe-Glyph.json",
-      "referenceNumber": "321",
+      "detailsUrl": "https://spdx.org/licenses/Adobe-Display-PostScript.json",
+      "referenceNumber": 499,
+      "name": "Adobe Display PostScript License",
+      "licenseId": "Adobe-Display-PostScript",
+      "seeAlso": [
+        "https://gitlab.freedesktop.org/xorg/xserver/-/blob/master/COPYING?ref_type\u003dheads#L752"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Adobe-Glyph.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Adobe-Glyph.json",
+      "referenceNumber": 492,
       "name": "Adobe Glyph List License",
       "licenseId": "Adobe-Glyph",
       "seeAlso": [
@@ -342,10 +102,102 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./Afmparse.html",
+      "reference": "https://spdx.org/licenses/Adobe-Utopia.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Afmparse.json",
-      "referenceNumber": "310",
+      "detailsUrl": "https://spdx.org/licenses/Adobe-Utopia.json",
+      "referenceNumber": 554,
+      "name": "Adobe Utopia Font License",
+      "licenseId": "Adobe-Utopia",
+      "seeAlso": [
+        "https://gitlab.freedesktop.org/xorg/font/adobe-utopia-100dpi/-/blob/master/COPYING?ref_type\u003dheads"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/ADSL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ADSL.json",
+      "referenceNumber": 76,
+      "name": "Amazon Digital Services License",
+      "licenseId": "ADSL",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/AmazonDigitalServicesLicense"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/AFL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/AFL-1.1.json",
+      "referenceNumber": 7,
+      "name": "Academic Free License v1.1",
+      "licenseId": "AFL-1.1",
+      "seeAlso": [
+        "http://opensource.linux-mirror.org/licenses/afl-1.1.txt",
+        "http://wayback.archive.org/web/20021004124254/http://www.opensource.org/licenses/academic.php"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/AFL-1.2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/AFL-1.2.json",
+      "referenceNumber": 480,
+      "name": "Academic Free License v1.2",
+      "licenseId": "AFL-1.2",
+      "seeAlso": [
+        "http://opensource.linux-mirror.org/licenses/afl-1.2.txt",
+        "http://wayback.archive.org/web/20021204204652/http://www.opensource.org/licenses/academic.php"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/AFL-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/AFL-2.0.json",
+      "referenceNumber": 41,
+      "name": "Academic Free License v2.0",
+      "licenseId": "AFL-2.0",
+      "seeAlso": [
+        "http://wayback.archive.org/web/20060924134533/http://www.opensource.org/licenses/afl-2.0.txt"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/AFL-2.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/AFL-2.1.json",
+      "referenceNumber": 682,
+      "name": "Academic Free License v2.1",
+      "licenseId": "AFL-2.1",
+      "seeAlso": [
+        "http://opensource.linux-mirror.org/licenses/afl-2.1.txt"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/AFL-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/AFL-3.0.json",
+      "referenceNumber": 343,
+      "name": "Academic Free License v3.0",
+      "licenseId": "AFL-3.0",
+      "seeAlso": [
+        "http://www.rosenlaw.com/AFL3.0.htm",
+        "https://opensource.org/licenses/afl-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Afmparse.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Afmparse.json",
+      "referenceNumber": 84,
       "name": "Afmparse License",
       "licenseId": "Afmparse",
       "seeAlso": [
@@ -354,87 +206,366 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./Aladdin.html",
+      "reference": "https://spdx.org/licenses/AGPL-1.0.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/AGPL-1.0.json",
+      "referenceNumber": 38,
+      "name": "Affero General Public License v1.0",
+      "licenseId": "AGPL-1.0",
+      "seeAlso": [
+        "http://www.affero.org/oagpl.html"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/AGPL-1.0-only.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Aladdin.json",
-      "referenceNumber": "293",
+      "detailsUrl": "https://spdx.org/licenses/AGPL-1.0-only.json",
+      "referenceNumber": 415,
+      "name": "Affero General Public License v1.0 only",
+      "licenseId": "AGPL-1.0-only",
+      "seeAlso": [
+        "http://www.affero.org/oagpl.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/AGPL-1.0-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/AGPL-1.0-or-later.json",
+      "referenceNumber": 24,
+      "name": "Affero General Public License v1.0 or later",
+      "licenseId": "AGPL-1.0-or-later",
+      "seeAlso": [
+        "http://www.affero.org/oagpl.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/AGPL-3.0.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/AGPL-3.0.json",
+      "referenceNumber": 427,
+      "name": "GNU Affero General Public License v3.0",
+      "licenseId": "AGPL-3.0",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/agpl.txt",
+        "https://opensource.org/licenses/AGPL-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/AGPL-3.0-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/AGPL-3.0-only.json",
+      "referenceNumber": 191,
+      "name": "GNU Affero General Public License v3.0 only",
+      "licenseId": "AGPL-3.0-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/agpl.txt",
+        "https://opensource.org/licenses/AGPL-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/AGPL-3.0-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/AGPL-3.0-or-later.json",
+      "referenceNumber": 469,
+      "name": "GNU Affero General Public License v3.0 or later",
+      "licenseId": "AGPL-3.0-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/agpl.txt",
+        "https://opensource.org/licenses/AGPL-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Aladdin.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Aladdin.json",
+      "referenceNumber": 495,
       "name": "Aladdin Free Public License",
       "licenseId": "Aladdin",
       "seeAlso": [
         "http://pages.cs.wisc.edu/~ghost/doc/AFPL/6.01/Public.htm"
       ],
+      "isOsiApproved": false,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/AMD-newlib.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/AMD-newlib.json",
+      "referenceNumber": 437,
+      "name": "AMD newlib License",
+      "licenseId": "AMD-newlib",
+      "seeAlso": [
+        "https://sourceware.org/git/?p\u003dnewlib-cygwin.git;a\u003dblob;f\u003dnewlib/libc/sys/a29khif/_close.S;h\u003d04f52ae00de1dafbd9055ad8d73c5c697a3aae7f;hb\u003dHEAD"
+      ],
       "isOsiApproved": false
     },
     {
-      "reference": "./Apache-1.0.html",
+      "reference": "https://spdx.org/licenses/AMDPLPA.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Apache-1.0.json",
-      "referenceNumber": "30",
+      "detailsUrl": "https://spdx.org/licenses/AMDPLPA.json",
+      "referenceNumber": 194,
+      "name": "AMD\u0027s plpa_map.c License",
+      "licenseId": "AMDPLPA",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/AMD_plpa_map_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/AML.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/AML.json",
+      "referenceNumber": 644,
+      "name": "Apple MIT License",
+      "licenseId": "AML",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Apple_MIT_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/AML-glslang.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/AML-glslang.json",
+      "referenceNumber": 439,
+      "name": "AML glslang variant License",
+      "licenseId": "AML-glslang",
+      "seeAlso": [
+        "https://github.com/KhronosGroup/glslang/blob/main/LICENSE.txt#L949",
+        "https://docs.omniverse.nvidia.com/install-guide/latest/common/licenses.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/AMPAS.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/AMPAS.json",
+      "referenceNumber": 15,
+      "name": "Academy of Motion Picture Arts and Sciences BSD",
+      "licenseId": "AMPAS",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/BSD#AMPASBSD"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/ANTLR-PD.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ANTLR-PD.json",
+      "referenceNumber": 25,
+      "name": "ANTLR Software Rights Notice",
+      "licenseId": "ANTLR-PD",
+      "seeAlso": [
+        "http://www.antlr2.org/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/ANTLR-PD-fallback.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ANTLR-PD-fallback.json",
+      "referenceNumber": 218,
+      "name": "ANTLR Software Rights Notice with license fallback",
+      "licenseId": "ANTLR-PD-fallback",
+      "seeAlso": [
+        "http://www.antlr2.org/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/any-OSI.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/any-OSI.json",
+      "referenceNumber": 74,
+      "name": "Any OSI License",
+      "licenseId": "any-OSI",
+      "seeAlso": [
+        "https://metacpan.org/pod/Exporter::Tidy#LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/any-OSI-perl-modules.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/any-OSI-perl-modules.json",
+      "referenceNumber": 230,
+      "name": "Any OSI License - Perl Modules",
+      "licenseId": "any-OSI-perl-modules",
+      "seeAlso": [
+        "https://metacpan.org/release/JUERD/Exporter-Tidy-0.09/view/Tidy.pm#LICENSE",
+        "https://metacpan.org/pod/Qmail::Deliverable::Client#LICENSE",
+        "https://metacpan.org/pod/Net::MQTT::Simple#LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Apache-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Apache-1.0.json",
+      "referenceNumber": 379,
       "name": "Apache License 1.0",
       "licenseId": "Apache-1.0",
       "seeAlso": [
         "http://www.apache.org/licenses/LICENSE-1.0"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": false,
+      "isFsfLibre": true
     },
     {
-      "reference": "./Apache-1.1.html",
+      "reference": "https://spdx.org/licenses/Apache-1.1.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Apache-1.1.json",
-      "referenceNumber": "254",
+      "detailsUrl": "https://spdx.org/licenses/Apache-1.1.json",
+      "referenceNumber": 111,
       "name": "Apache License 1.1",
       "licenseId": "Apache-1.1",
       "seeAlso": [
         "http://apache.org/licenses/LICENSE-1.1",
         "https://opensource.org/licenses/Apache-1.1"
       ],
-      "isOsiApproved": true
+      "isOsiApproved": true,
+      "isFsfLibre": true
     },
     {
-      "reference": "./Apache-2.0.html",
+      "reference": "https://spdx.org/licenses/Apache-2.0.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Apache-2.0.json",
-      "referenceNumber": "343",
+      "detailsUrl": "https://spdx.org/licenses/Apache-2.0.json",
+      "referenceNumber": 162,
       "name": "Apache License 2.0",
       "licenseId": "Apache-2.0",
       "seeAlso": [
-        "http://www.apache.org/licenses/LICENSE-2.0",
-        "https://opensource.org/licenses/Apache-2.0"
+        "https://www.apache.org/licenses/LICENSE-2.0",
+        "https://opensource.org/licenses/Apache-2.0",
+        "https://opensource.org/license/apache-2-0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/APAFML.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/APAFML.json",
+      "referenceNumber": 474,
+      "name": "Adobe Postscript AFM License",
+      "licenseId": "APAFML",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/AdobePostscriptAFM"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/APL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/APL-1.0.json",
+      "referenceNumber": 127,
+      "name": "Adaptive Public License 1.0",
+      "licenseId": "APL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/APL-1.0"
       ],
       "isOsiApproved": true
     },
     {
-      "reference": "./Artistic-1.0.html",
+      "reference": "https://spdx.org/licenses/App-s2p.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Artistic-1.0.json",
-      "referenceNumber": "253",
+      "detailsUrl": "https://spdx.org/licenses/App-s2p.json",
+      "referenceNumber": 155,
+      "name": "App::s2p License",
+      "licenseId": "App-s2p",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/App-s2p"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/APSL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/APSL-1.0.json",
+      "referenceNumber": 86,
+      "name": "Apple Public Source License 1.0",
+      "licenseId": "APSL-1.0",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Apple_Public_Source_License_1.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/APSL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/APSL-1.1.json",
+      "referenceNumber": 23,
+      "name": "Apple Public Source License 1.1",
+      "licenseId": "APSL-1.1",
+      "seeAlso": [
+        "http://www.opensource.apple.com/source/IOSerialFamily/IOSerialFamily-7/APPLE_LICENSE"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/APSL-1.2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/APSL-1.2.json",
+      "referenceNumber": 265,
+      "name": "Apple Public Source License 1.2",
+      "licenseId": "APSL-1.2",
+      "seeAlso": [
+        "http://www.samurajdata.se/opensource/mirror/licenses/apsl.php"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/APSL-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/APSL-2.0.json",
+      "referenceNumber": 568,
+      "name": "Apple Public Source License 2.0",
+      "licenseId": "APSL-2.0",
+      "seeAlso": [
+        "http://www.opensource.apple.com/license/apsl/"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Arphic-1999.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Arphic-1999.json",
+      "referenceNumber": 649,
+      "name": "Arphic Public License",
+      "licenseId": "Arphic-1999",
+      "seeAlso": [
+        "http://ftp.gnu.org/gnu/non-gnu/chinese-fonts-truetype/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Artistic-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Artistic-1.0.json",
+      "referenceNumber": 388,
       "name": "Artistic License 1.0",
       "licenseId": "Artistic-1.0",
       "seeAlso": [
         "https://opensource.org/licenses/Artistic-1.0"
       ],
-      "isOsiApproved": true
+      "isOsiApproved": true,
+      "isFsfLibre": false
     },
     {
-      "reference": "./Artistic-1.0-Perl.html",
+      "reference": "https://spdx.org/licenses/Artistic-1.0-cl8.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Artistic-1.0-Perl.json",
-      "referenceNumber": "285",
-      "name": "Artistic License 1.0 (Perl)",
-      "licenseId": "Artistic-1.0-Perl",
-      "seeAlso": [
-        "http://dev.perl.org/licenses/artistic.html"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Artistic-1.0-cl8.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Artistic-1.0-cl8.json",
-      "referenceNumber": "213",
+      "detailsUrl": "https://spdx.org/licenses/Artistic-1.0-cl8.json",
+      "referenceNumber": 291,
       "name": "Artistic License 1.0 w/clause 8",
       "licenseId": "Artistic-1.0-cl8",
       "seeAlso": [
@@ -443,247 +574,97 @@
       "isOsiApproved": true
     },
     {
-      "reference": "./Artistic-2.0.html",
+      "reference": "https://spdx.org/licenses/Artistic-1.0-Perl.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Artistic-2.0.json",
-      "referenceNumber": "70",
+      "detailsUrl": "https://spdx.org/licenses/Artistic-1.0-Perl.json",
+      "referenceNumber": 20,
+      "name": "Artistic License 1.0 (Perl)",
+      "licenseId": "Artistic-1.0-Perl",
+      "seeAlso": [
+        "http://dev.perl.org/licenses/artistic.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Artistic-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Artistic-2.0.json",
+      "referenceNumber": 217,
       "name": "Artistic License 2.0",
       "licenseId": "Artistic-2.0",
       "seeAlso": [
         "http://www.perlfoundation.org/artistic_license_2_0",
+        "https://www.perlfoundation.org/artistic-license-20.html",
         "https://opensource.org/licenses/artistic-license-2.0"
       ],
-      "isOsiApproved": true
+      "isOsiApproved": true,
+      "isFsfLibre": true
     },
     {
-      "reference": "./BSD-1-Clause.html",
+      "reference": "https://spdx.org/licenses/Artistic-dist.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/BSD-1-Clause.json",
-      "referenceNumber": "365",
-      "name": "BSD 1-Clause License",
-      "licenseId": "BSD-1-Clause",
+      "detailsUrl": "https://spdx.org/licenses/Artistic-dist.json",
+      "referenceNumber": 511,
+      "name": "Artistic License 1.0 (dist)",
+      "licenseId": "Artistic-dist",
       "seeAlso": [
-        "https://svnweb.freebsd.org/base/head/include/ifaddrs.h?revision\u003d326823"
+        "https://github.com/pexip/os-perl/blob/833cf4c86cc465ccfc627ff16db67e783156a248/debian/copyright#L2720-L2845"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./BSD-2-Clause.html",
+      "reference": "https://spdx.org/licenses/Aspell-RU.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/BSD-2-Clause.json",
-      "referenceNumber": "286",
-      "name": "BSD 2-Clause \"Simplified\" License",
-      "licenseId": "BSD-2-Clause",
+      "detailsUrl": "https://spdx.org/licenses/Aspell-RU.json",
+      "referenceNumber": 231,
+      "name": "Aspell Russian License",
+      "licenseId": "Aspell-RU",
       "seeAlso": [
-        "https://opensource.org/licenses/BSD-2-Clause"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./BSD-2-Clause-FreeBSD.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/BSD-2-Clause-FreeBSD.json",
-      "referenceNumber": "261",
-      "name": "BSD 2-Clause FreeBSD License",
-      "licenseId": "BSD-2-Clause-FreeBSD",
-      "seeAlso": [
-        "http://www.freebsd.org/copyright/freebsd-license.html"
+        "https://ftp.gnu.org/gnu/aspell/dict/ru/aspell6-ru-0.99f7-1.tar.bz2"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./BSD-2-Clause-NetBSD.html",
+      "reference": "https://spdx.org/licenses/ASWF-Digital-Assets-1.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/BSD-2-Clause-NetBSD.json",
-      "referenceNumber": "173",
-      "name": "BSD 2-Clause NetBSD License",
-      "licenseId": "BSD-2-Clause-NetBSD",
+      "detailsUrl": "https://spdx.org/licenses/ASWF-Digital-Assets-1.0.json",
+      "referenceNumber": 340,
+      "name": "ASWF Digital Assets License version 1.0",
+      "licenseId": "ASWF-Digital-Assets-1.0",
       "seeAlso": [
-        "http://www.netbsd.org/about/redistribution.html#default"
+        "https://github.com/AcademySoftwareFoundation/foundation/blob/main/digital_assets/aswf_digital_assets_license_v1.0.txt"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./BSD-2-Clause-Patent.html",
+      "reference": "https://spdx.org/licenses/ASWF-Digital-Assets-1.1.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/BSD-2-Clause-Patent.json",
-      "referenceNumber": "339",
-      "name": "BSD-2-Clause Plus Patent License",
-      "licenseId": "BSD-2-Clause-Patent",
+      "detailsUrl": "https://spdx.org/licenses/ASWF-Digital-Assets-1.1.json",
+      "referenceNumber": 153,
+      "name": "ASWF Digital Assets License 1.1",
+      "licenseId": "ASWF-Digital-Assets-1.1",
       "seeAlso": [
-        "https://opensource.org/licenses/BSDplusPatent"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./BSD-3-Clause.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause.json",
-      "referenceNumber": "188",
-      "name": "BSD 3-Clause \"New\" or \"Revised\" License",
-      "licenseId": "BSD-3-Clause",
-      "seeAlso": [
-        "https://opensource.org/licenses/BSD-3-Clause"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./BSD-3-Clause-Attribution.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-Attribution.json",
-      "referenceNumber": "37",
-      "name": "BSD with attribution",
-      "licenseId": "BSD-3-Clause-Attribution",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/BSD_with_Attribution"
+        "https://github.com/AcademySoftwareFoundation/foundation/blob/main/digital_assets/aswf_digital_assets_license_v1.1.txt"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./BSD-3-Clause-Clear.html",
+      "reference": "https://spdx.org/licenses/Baekmuk.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-Clear.json",
-      "referenceNumber": "79",
-      "name": "BSD 3-Clause Clear License",
-      "licenseId": "BSD-3-Clause-Clear",
+      "detailsUrl": "https://spdx.org/licenses/Baekmuk.json",
+      "referenceNumber": 311,
+      "name": "Baekmuk License",
+      "licenseId": "Baekmuk",
       "seeAlso": [
-        "http://labs.metacarta.com/license-explanation.html#license"
+        "https://fedoraproject.org/wiki/Licensing:Baekmuk?rd\u003dLicensing/Baekmuk"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./BSD-3-Clause-LBNL.html",
+      "reference": "https://spdx.org/licenses/Bahyph.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-LBNL.json",
-      "referenceNumber": "136",
-      "name": "Lawrence Berkeley National Labs BSD variant license",
-      "licenseId": "BSD-3-Clause-LBNL",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/LBNLBSD"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./BSD-3-Clause-No-Nuclear-License.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License.json",
-      "referenceNumber": "56",
-      "name": "BSD 3-Clause No Nuclear License",
-      "licenseId": "BSD-3-Clause-No-Nuclear-License",
-      "seeAlso": [
-        "http://download.oracle.com/otn-pub/java/licenses/bsd.txt?AuthParam\u003d1467140197_43d516ce1776bd08a58235a7785be1cc"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./BSD-3-Clause-No-Nuclear-License-2014.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License-2014.json",
-      "referenceNumber": "320",
-      "name": "BSD 3-Clause No Nuclear License 2014",
-      "licenseId": "BSD-3-Clause-No-Nuclear-License-2014",
-      "seeAlso": [
-        "https://java.net/projects/javaeetutorial/pages/BerkeleyLicense"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./BSD-3-Clause-No-Nuclear-Warranty.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-No-Nuclear-Warranty.json",
-      "referenceNumber": "107",
-      "name": "BSD 3-Clause No Nuclear Warranty",
-      "licenseId": "BSD-3-Clause-No-Nuclear-Warranty",
-      "seeAlso": [
-        "https://jogamp.org/git/?p\u003dgluegen.git;a\u003dblob_plain;f\u003dLICENSE.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./BSD-3-Clause-Open-MPI.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-Open-MPI.json",
-      "referenceNumber": "199",
-      "name": "BSD 3-Clause Open MPI variant",
-      "licenseId": "BSD-3-Clause-Open-MPI",
-      "seeAlso": [
-        "https://www.open-mpi.org/community/license.php",
-        "http://www.netlib.org/lapack/LICENSE.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./BSD-4-Clause.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/BSD-4-Clause.json",
-      "referenceNumber": "63",
-      "name": "BSD 4-Clause \"Original\" or \"Old\" License",
-      "licenseId": "BSD-4-Clause",
-      "seeAlso": [
-        "http://directory.fsf.org/wiki/License:BSD_4Clause"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./BSD-4-Clause-UC.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/BSD-4-Clause-UC.json",
-      "referenceNumber": "349",
-      "name": "BSD-4-Clause (University of California-Specific)",
-      "licenseId": "BSD-4-Clause-UC",
-      "seeAlso": [
-        "http://www.freebsd.org/copyright/license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./BSD-Protection.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/BSD-Protection.json",
-      "referenceNumber": "376",
-      "name": "BSD Protection License",
-      "licenseId": "BSD-Protection",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/BSD_Protection_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./BSD-Source-Code.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/BSD-Source-Code.json",
-      "referenceNumber": "157",
-      "name": "BSD Source Code Attribution",
-      "licenseId": "BSD-Source-Code",
-      "seeAlso": [
-        "https://github.com/robbiehanson/CocoaHTTPServer/blob/master/LICENSE.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./BSL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/BSL-1.0.json",
-      "referenceNumber": "274",
-      "name": "Boost Software License 1.0",
-      "licenseId": "BSL-1.0",
-      "seeAlso": [
-        "http://www.boost.org/LICENSE_1_0.txt",
-        "https://opensource.org/licenses/BSL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Bahyph.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Bahyph.json",
-      "referenceNumber": "140",
+      "detailsUrl": "https://spdx.org/licenses/Bahyph.json",
+      "referenceNumber": 505,
       "name": "Bahyph License",
       "licenseId": "Bahyph",
       "seeAlso": [
@@ -692,10 +673,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./Barr.html",
+      "reference": "https://spdx.org/licenses/Barr.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Barr.json",
-      "referenceNumber": "117",
+      "detailsUrl": "https://spdx.org/licenses/Barr.json",
+      "referenceNumber": 420,
       "name": "Barr License",
       "licenseId": "Barr",
       "seeAlso": [
@@ -704,10 +685,22 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./Beerware.html",
+      "reference": "https://spdx.org/licenses/bcrypt-Solar-Designer.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Beerware.json",
-      "referenceNumber": "234",
+      "detailsUrl": "https://spdx.org/licenses/bcrypt-Solar-Designer.json",
+      "referenceNumber": 167,
+      "name": "bcrypt Solar Designer License",
+      "licenseId": "bcrypt-Solar-Designer",
+      "seeAlso": [
+        "https://github.com/bcrypt-ruby/bcrypt-ruby/blob/master/ext/mri/crypt_blowfish.c"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Beerware.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Beerware.json",
+      "referenceNumber": 556,
       "name": "Beerware License",
       "licenseId": "Beerware",
       "seeAlso": [
@@ -717,10 +710,36 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./BitTorrent-1.0.html",
+      "reference": "https://spdx.org/licenses/Bitstream-Charter.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/BitTorrent-1.0.json",
-      "referenceNumber": "193",
+      "detailsUrl": "https://spdx.org/licenses/Bitstream-Charter.json",
+      "referenceNumber": 47,
+      "name": "Bitstream Charter Font License",
+      "licenseId": "Bitstream-Charter",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Charter#License_Text",
+        "https://raw.githubusercontent.com/blackhole89/notekit/master/data/fonts/Charter%20license.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Bitstream-Vera.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Bitstream-Vera.json",
+      "referenceNumber": 208,
+      "name": "Bitstream Vera Font License",
+      "licenseId": "Bitstream-Vera",
+      "seeAlso": [
+        "https://web.archive.org/web/20080207013128/http://www.gnome.org/fonts/",
+        "https://docubrain.com/sites/default/files/licenses/bitstream-vera.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BitTorrent-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BitTorrent-1.0.json",
+      "referenceNumber": 156,
       "name": "BitTorrent Open Source License v1.0",
       "licenseId": "BitTorrent-1.0",
       "seeAlso": [
@@ -729,35 +748,74 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./BitTorrent-1.1.html",
+      "reference": "https://spdx.org/licenses/BitTorrent-1.1.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/BitTorrent-1.1.json",
-      "referenceNumber": "175",
+      "detailsUrl": "https://spdx.org/licenses/BitTorrent-1.1.json",
+      "referenceNumber": 325,
       "name": "BitTorrent Open Source License v1.1",
       "licenseId": "BitTorrent-1.1",
       "seeAlso": [
         "http://directory.fsf.org/wiki/License:BitTorrentOSL1.1"
       ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/blessing.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/blessing.json",
+      "referenceNumber": 680,
+      "name": "SQLite Blessing",
+      "licenseId": "blessing",
+      "seeAlso": [
+        "https://www.sqlite.org/src/artifact/e33a4df7e32d742a?ln\u003d4-9",
+        "https://sqlite.org/src/artifact/df5091916dbb40e6"
+      ],
       "isOsiApproved": false
     },
     {
-      "reference": "./BlueOak-1.0.0.html",
+      "reference": "https://spdx.org/licenses/BlueOak-1.0.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/BlueOak-1.0.0.json",
-      "referenceNumber": "196",
+      "detailsUrl": "https://spdx.org/licenses/BlueOak-1.0.0.json",
+      "referenceNumber": 51,
       "name": "Blue Oak Model License 1.0.0",
       "licenseId": "BlueOak-1.0.0",
       "seeAlso": [
         "https://blueoakcouncil.org/license/1.0.0"
       ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Boehm-GC.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Boehm-GC.json",
+      "referenceNumber": 92,
+      "name": "Boehm-Demers-Weiser GC License",
+      "licenseId": "Boehm-GC",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing:MIT#Another_Minimal_variant_(found_in_libatomic_ops)",
+        "https://github.com/uim/libgcroots/blob/master/COPYING",
+        "https://github.com/ivmai/libatomic_ops/blob/master/LICENSE"
+      ],
       "isOsiApproved": false
     },
     {
-      "reference": "./Borceux.html",
+      "reference": "https://spdx.org/licenses/Boehm-GC-without-fee.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Borceux.json",
-      "referenceNumber": "284",
+      "detailsUrl": "https://spdx.org/licenses/Boehm-GC-without-fee.json",
+      "referenceNumber": 466,
+      "name": "Boehm-Demers-Weiser GC License (without fee)",
+      "licenseId": "Boehm-GC-without-fee",
+      "seeAlso": [
+        "https://github.com/MariaDB/server/blob/11.6/libmysqld/lib_sql.cc"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Borceux.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Borceux.json",
+      "referenceNumber": 335,
       "name": "Borceux license",
       "licenseId": "Borceux",
       "seeAlso": [
@@ -766,10 +824,610 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./CATOSL-1.1.html",
+      "reference": "https://spdx.org/licenses/Brian-Gladman-2-Clause.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CATOSL-1.1.json",
-      "referenceNumber": "218",
+      "detailsUrl": "https://spdx.org/licenses/Brian-Gladman-2-Clause.json",
+      "referenceNumber": 198,
+      "name": "Brian Gladman 2-Clause License",
+      "licenseId": "Brian-Gladman-2-Clause",
+      "seeAlso": [
+        "https://github.com/krb5/krb5/blob/krb5-1.21.2-final/NOTICE#L140-L156",
+        "https://web.mit.edu/kerberos/krb5-1.21/doc/mitK5license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Brian-Gladman-3-Clause.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Brian-Gladman-3-Clause.json",
+      "referenceNumber": 675,
+      "name": "Brian Gladman 3-Clause License",
+      "licenseId": "Brian-Gladman-3-Clause",
+      "seeAlso": [
+        "https://github.com/SWI-Prolog/packages-clib/blob/master/sha1/brg_endian.h"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-1-Clause.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-1-Clause.json",
+      "referenceNumber": 286,
+      "name": "BSD 1-Clause License",
+      "licenseId": "BSD-1-Clause",
+      "seeAlso": [
+        "https://svnweb.freebsd.org/base/head/include/ifaddrs.h?revision\u003d326823"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-2-Clause.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause.json",
+      "referenceNumber": 430,
+      "name": "BSD 2-Clause \"Simplified\" License",
+      "licenseId": "BSD-2-Clause",
+      "seeAlso": [
+        "https://opensource.org/licenses/BSD-2-Clause"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-2-Clause-Darwin.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-Darwin.json",
+      "referenceNumber": 477,
+      "name": "BSD 2-Clause - Ian Darwin variant",
+      "licenseId": "BSD-2-Clause-Darwin",
+      "seeAlso": [
+        "https://github.com/file/file/blob/master/COPYING"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-2-Clause-first-lines.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-first-lines.json",
+      "referenceNumber": 543,
+      "name": "BSD 2-Clause - first lines requirement",
+      "licenseId": "BSD-2-Clause-first-lines",
+      "seeAlso": [
+        "https://github.com/krb5/krb5/blob/krb5-1.21.2-final/NOTICE#L664-L690",
+        "https://web.mit.edu/kerberos/krb5-1.21/doc/mitK5license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-2-Clause-FreeBSD.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-FreeBSD.json",
+      "referenceNumber": 622,
+      "name": "BSD 2-Clause FreeBSD License",
+      "licenseId": "BSD-2-Clause-FreeBSD",
+      "seeAlso": [
+        "http://www.freebsd.org/copyright/freebsd-license.html"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-2-Clause-NetBSD.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-NetBSD.json",
+      "referenceNumber": 531,
+      "name": "BSD 2-Clause NetBSD License",
+      "licenseId": "BSD-2-Clause-NetBSD",
+      "seeAlso": [
+        "http://www.netbsd.org/about/redistribution.html#default"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-2-Clause-Patent.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-Patent.json",
+      "referenceNumber": 584,
+      "name": "BSD-2-Clause Plus Patent License",
+      "licenseId": "BSD-2-Clause-Patent",
+      "seeAlso": [
+        "https://opensource.org/licenses/BSDplusPatent"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-2-Clause-pkgconf-disclaimer.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-pkgconf-disclaimer.json",
+      "referenceNumber": 624,
+      "name": "BSD 2-Clause pkgconf disclaimer variant",
+      "licenseId": "BSD-2-Clause-pkgconf-disclaimer",
+      "seeAlso": [
+        "https://github.com/audacious-media-player/audacious/blob/master/src/audacious/main.cc",
+        "https://github.com/audacious-media-player/audacious/blob/master/COPYING"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-2-Clause-Views.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-Views.json",
+      "referenceNumber": 536,
+      "name": "BSD 2-Clause with views sentence",
+      "licenseId": "BSD-2-Clause-Views",
+      "seeAlso": [
+        "http://www.freebsd.org/copyright/freebsd-license.html",
+        "https://people.freebsd.org/~ivoras/wine/patch-wine-nvidia.sh",
+        "https://github.com/protegeproject/protege/blob/master/license.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-3-Clause.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause.json",
+      "referenceNumber": 567,
+      "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+      "licenseId": "BSD-3-Clause",
+      "seeAlso": [
+        "https://opensource.org/licenses/BSD-3-Clause",
+        "https://www.eclipse.org/org/documents/edl-v10.php"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-3-Clause-acpica.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-acpica.json",
+      "referenceNumber": 277,
+      "name": "BSD 3-Clause acpica variant",
+      "licenseId": "BSD-3-Clause-acpica",
+      "seeAlso": [
+        "https://github.com/acpica/acpica/blob/master/source/common/acfileio.c#L119"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-3-Clause-Attribution.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Attribution.json",
+      "referenceNumber": 159,
+      "name": "BSD with attribution",
+      "licenseId": "BSD-3-Clause-Attribution",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/BSD_with_Attribution"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-3-Clause-Clear.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Clear.json",
+      "referenceNumber": 259,
+      "name": "BSD 3-Clause Clear License",
+      "licenseId": "BSD-3-Clause-Clear",
+      "seeAlso": [
+        "http://labs.metacarta.com/license-explanation.html#license"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-3-Clause-flex.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-flex.json",
+      "referenceNumber": 205,
+      "name": "BSD 3-Clause Flex variant",
+      "licenseId": "BSD-3-Clause-flex",
+      "seeAlso": [
+        "https://github.com/westes/flex/blob/master/COPYING"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-3-Clause-HP.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-HP.json",
+      "referenceNumber": 643,
+      "name": "Hewlett-Packard BSD variant license",
+      "licenseId": "BSD-3-Clause-HP",
+      "seeAlso": [
+        "https://github.com/zdohnal/hplip/blob/master/COPYING#L939"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-3-Clause-LBNL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-LBNL.json",
+      "referenceNumber": 6,
+      "name": "Lawrence Berkeley National Labs BSD variant license",
+      "licenseId": "BSD-3-Clause-LBNL",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/LBNLBSD"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-3-Clause-Modification.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Modification.json",
+      "referenceNumber": 497,
+      "name": "BSD 3-Clause Modification",
+      "licenseId": "BSD-3-Clause-Modification",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing:BSD#Modification_Variant"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-3-Clause-No-Military-License.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-No-Military-License.json",
+      "referenceNumber": 498,
+      "name": "BSD 3-Clause No Military License",
+      "licenseId": "BSD-3-Clause-No-Military-License",
+      "seeAlso": [
+        "https://gitlab.syncad.com/hive/dhive/-/blob/master/LICENSE",
+        "https://github.com/greymass/swift-eosio/blob/master/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License.json",
+      "referenceNumber": 108,
+      "name": "BSD 3-Clause No Nuclear License",
+      "licenseId": "BSD-3-Clause-No-Nuclear-License",
+      "seeAlso": [
+        "http://download.oracle.com/otn-pub/java/licenses/bsd.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License-2014.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License-2014.json",
+      "referenceNumber": 239,
+      "name": "BSD 3-Clause No Nuclear License 2014",
+      "licenseId": "BSD-3-Clause-No-Nuclear-License-2014",
+      "seeAlso": [
+        "https://java.net/projects/javaeetutorial/pages/BerkeleyLicense"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-Warranty.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-Warranty.json",
+      "referenceNumber": 606,
+      "name": "BSD 3-Clause No Nuclear Warranty",
+      "licenseId": "BSD-3-Clause-No-Nuclear-Warranty",
+      "seeAlso": [
+        "https://jogamp.org/git/?p\u003dgluegen.git;a\u003dblob_plain;f\u003dLICENSE.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-3-Clause-Open-MPI.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Open-MPI.json",
+      "referenceNumber": 637,
+      "name": "BSD 3-Clause Open MPI variant",
+      "licenseId": "BSD-3-Clause-Open-MPI",
+      "seeAlso": [
+        "https://www.open-mpi.org/community/license.php",
+        "http://www.netlib.org/lapack/LICENSE.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-3-Clause-Sun.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Sun.json",
+      "referenceNumber": 240,
+      "name": "BSD 3-Clause Sun Microsystems",
+      "licenseId": "BSD-3-Clause-Sun",
+      "seeAlso": [
+        "https://github.com/xmlark/msv/blob/b9316e2f2270bc1606952ea4939ec87fbba157f3/xsdlib/src/main/java/com/sun/msv/datatype/regexp/InternalImpl.java"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-4-Clause.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-4-Clause.json",
+      "referenceNumber": 227,
+      "name": "BSD 4-Clause \"Original\" or \"Old\" License",
+      "licenseId": "BSD-4-Clause",
+      "seeAlso": [
+        "http://directory.fsf.org/wiki/License:BSD_4Clause"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-4-Clause-Shortened.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-4-Clause-Shortened.json",
+      "referenceNumber": 269,
+      "name": "BSD 4 Clause Shortened",
+      "licenseId": "BSD-4-Clause-Shortened",
+      "seeAlso": [
+        "https://metadata.ftp-master.debian.org/changelogs//main/a/arpwatch/arpwatch_2.1a15-7_copyright"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-4-Clause-UC.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-4-Clause-UC.json",
+      "referenceNumber": 21,
+      "name": "BSD-4-Clause (University of California-Specific)",
+      "licenseId": "BSD-4-Clause-UC",
+      "seeAlso": [
+        "http://www.freebsd.org/copyright/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-4.3RENO.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-4.3RENO.json",
+      "referenceNumber": 434,
+      "name": "BSD 4.3 RENO License",
+      "licenseId": "BSD-4.3RENO",
+      "seeAlso": [
+        "https://sourceware.org/git/?p\u003dbinutils-gdb.git;a\u003dblob;f\u003dlibiberty/strcasecmp.c;h\u003d131d81c2ce7881fa48c363dc5bf5fb302c61ce0b;hb\u003dHEAD",
+        "https://git.openldap.org/openldap/openldap/-/blob/master/COPYRIGHT#L55-63"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-4.3TAHOE.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-4.3TAHOE.json",
+      "referenceNumber": 685,
+      "name": "BSD 4.3 TAHOE License",
+      "licenseId": "BSD-4.3TAHOE",
+      "seeAlso": [
+        "https://github.com/389ds/389-ds-base/blob/main/ldap/include/sysexits-compat.h#L15",
+        "https://git.savannah.gnu.org/cgit/indent.git/tree/doc/indent.texi?id\u003da74c6b4ee49397cf330b333da1042bffa60ed14f#n1788"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-Advertising-Acknowledgement.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-Advertising-Acknowledgement.json",
+      "referenceNumber": 345,
+      "name": "BSD Advertising Acknowledgement License",
+      "licenseId": "BSD-Advertising-Acknowledgement",
+      "seeAlso": [
+        "https://github.com/python-excel/xlrd/blob/master/LICENSE#L33"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-Attribution-HPND-disclaimer.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-Attribution-HPND-disclaimer.json",
+      "referenceNumber": 506,
+      "name": "BSD with Attribution and HPND disclaimer",
+      "licenseId": "BSD-Attribution-HPND-disclaimer",
+      "seeAlso": [
+        "https://github.com/cyrusimap/cyrus-sasl/blob/master/COPYING"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-Inferno-Nettverk.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-Inferno-Nettverk.json",
+      "referenceNumber": 535,
+      "name": "BSD-Inferno-Nettverk",
+      "licenseId": "BSD-Inferno-Nettverk",
+      "seeAlso": [
+        "https://www.inet.no/dante/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-Protection.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-Protection.json",
+      "referenceNumber": 163,
+      "name": "BSD Protection License",
+      "licenseId": "BSD-Protection",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/BSD_Protection_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-Source-beginning-file.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-Source-beginning-file.json",
+      "referenceNumber": 383,
+      "name": "BSD Source Code Attribution - beginning of file variant",
+      "licenseId": "BSD-Source-beginning-file",
+      "seeAlso": [
+        "https://github.com/lattera/freebsd/blob/master/sys/cam/cam.c#L4"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-Source-Code.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-Source-Code.json",
+      "referenceNumber": 450,
+      "name": "BSD Source Code Attribution",
+      "licenseId": "BSD-Source-Code",
+      "seeAlso": [
+        "https://github.com/robbiehanson/CocoaHTTPServer/blob/master/LICENSE.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-Systemics.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-Systemics.json",
+      "referenceNumber": 602,
+      "name": "Systemics BSD variant license",
+      "licenseId": "BSD-Systemics",
+      "seeAlso": [
+        "https://metacpan.org/release/DPARIS/Crypt-DES-2.07/source/COPYRIGHT"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSD-Systemics-W3Works.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSD-Systemics-W3Works.json",
+      "referenceNumber": 422,
+      "name": "Systemics W3Works BSD variant license",
+      "licenseId": "BSD-Systemics-W3Works",
+      "seeAlso": [
+        "https://metacpan.org/release/DPARIS/Crypt-Blowfish-2.14/source/COPYRIGHT#L7"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/BSL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BSL-1.0.json",
+      "referenceNumber": 130,
+      "name": "Boost Software License 1.0",
+      "licenseId": "BSL-1.0",
+      "seeAlso": [
+        "http://www.boost.org/LICENSE_1_0.txt",
+        "https://opensource.org/licenses/BSL-1.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/BUSL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/BUSL-1.1.json",
+      "referenceNumber": 234,
+      "name": "Business Source License 1.1",
+      "licenseId": "BUSL-1.1",
+      "seeAlso": [
+        "https://mariadb.com/bsl11/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/bzip2-1.0.5.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/bzip2-1.0.5.json",
+      "referenceNumber": 412,
+      "name": "bzip2 and libbzip2 License v1.0.5",
+      "licenseId": "bzip2-1.0.5",
+      "seeAlso": [
+        "https://sourceware.org/bzip2/1.0.5/bzip2-manual-1.0.5.html",
+        "http://bzip.org/1.0.5/bzip2-manual-1.0.5.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/bzip2-1.0.6.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/bzip2-1.0.6.json",
+      "referenceNumber": 243,
+      "name": "bzip2 and libbzip2 License v1.0.6",
+      "licenseId": "bzip2-1.0.6",
+      "seeAlso": [
+        "https://sourceware.org/git/?p\u003dbzip2.git;a\u003dblob;f\u003dLICENSE;hb\u003dbzip2-1.0.6",
+        "http://bzip.org/1.0.5/bzip2-manual-1.0.5.html",
+        "https://sourceware.org/cgit/valgrind/tree/mpi/libmpiwrap.c"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/C-UDA-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/C-UDA-1.0.json",
+      "referenceNumber": 660,
+      "name": "Computational Use of Data Agreement v1.0",
+      "licenseId": "C-UDA-1.0",
+      "seeAlso": [
+        "https://github.com/microsoft/Computational-Use-of-Data-Agreement/blob/master/C-UDA-1.0.md",
+        "https://cdla.dev/computational-use-of-data-agreement-v1-0/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CAL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CAL-1.0.json",
+      "referenceNumber": 305,
+      "name": "Cryptographic Autonomy License 1.0",
+      "licenseId": "CAL-1.0",
+      "seeAlso": [
+        "http://cryptographicautonomylicense.com/license-text.html",
+        "https://opensource.org/licenses/CAL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CAL-1.0-Combined-Work-Exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CAL-1.0-Combined-Work-Exception.json",
+      "referenceNumber": 569,
+      "name": "Cryptographic Autonomy License 1.0 (Combined Work Exception)",
+      "licenseId": "CAL-1.0-Combined-Work-Exception",
+      "seeAlso": [
+        "http://cryptographicautonomylicense.com/license-text.html",
+        "https://opensource.org/licenses/CAL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Caldera.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Caldera.json",
+      "referenceNumber": 483,
+      "name": "Caldera License",
+      "licenseId": "Caldera",
+      "seeAlso": [
+        "http://www.lemis.com/grog/UNIX/ancient-source-all.pdf"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Caldera-no-preamble.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Caldera-no-preamble.json",
+      "referenceNumber": 401,
+      "name": "Caldera License (without preamble)",
+      "licenseId": "Caldera-no-preamble",
+      "seeAlso": [
+        "https://github.com/apache/apr/blob/trunk/LICENSE#L298C6-L298C29"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Catharon.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Catharon.json",
+      "referenceNumber": 581,
+      "name": "Catharon License",
+      "licenseId": "Catharon",
+      "seeAlso": [
+        "https://github.com/scummvm/scummvm/blob/v2.8.0/LICENSES/CatharonLicense.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CATOSL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CATOSL-1.1.json",
+      "referenceNumber": 97,
       "name": "Computer Associates Trusted Open Source License 1.1",
       "licenseId": "CATOSL-1.1",
       "seeAlso": [
@@ -778,10 +1436,10 @@
       "isOsiApproved": true
     },
     {
-      "reference": "./CC-BY-1.0.html",
+      "reference": "https://spdx.org/licenses/CC-BY-1.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-1.0.json",
-      "referenceNumber": "21",
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-1.0.json",
+      "referenceNumber": 559,
       "name": "Creative Commons Attribution 1.0 Generic",
       "licenseId": "CC-BY-1.0",
       "seeAlso": [
@@ -790,10 +1448,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./CC-BY-2.0.html",
+      "reference": "https://spdx.org/licenses/CC-BY-2.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-2.0.json",
-      "referenceNumber": "55",
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-2.0.json",
+      "referenceNumber": 441,
       "name": "Creative Commons Attribution 2.0 Generic",
       "licenseId": "CC-BY-2.0",
       "seeAlso": [
@@ -802,10 +1460,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./CC-BY-2.5.html",
+      "reference": "https://spdx.org/licenses/CC-BY-2.5.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-2.5.json",
-      "referenceNumber": "174",
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-2.5.json",
+      "referenceNumber": 292,
       "name": "Creative Commons Attribution 2.5 Generic",
       "licenseId": "CC-BY-2.5",
       "seeAlso": [
@@ -814,10 +1472,22 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./CC-BY-3.0.html",
+      "reference": "https://spdx.org/licenses/CC-BY-2.5-AU.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-3.0.json",
-      "referenceNumber": "322",
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-2.5-AU.json",
+      "referenceNumber": 126,
+      "name": "Creative Commons Attribution 2.5 Australia",
+      "licenseId": "CC-BY-2.5-AU",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by/2.5/au/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0.json",
+      "referenceNumber": 576,
       "name": "Creative Commons Attribution 3.0 Unported",
       "licenseId": "CC-BY-3.0",
       "seeAlso": [
@@ -826,83 +1496,172 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./CC-BY-4.0.html",
+      "reference": "https://spdx.org/licenses/CC-BY-3.0-AT.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-4.0.json",
-      "referenceNumber": "203",
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-AT.json",
+      "referenceNumber": 107,
+      "name": "Creative Commons Attribution 3.0 Austria",
+      "licenseId": "CC-BY-3.0-AT",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by/3.0/at/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-3.0-AU.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-AU.json",
+      "referenceNumber": 648,
+      "name": "Creative Commons Attribution 3.0 Australia",
+      "licenseId": "CC-BY-3.0-AU",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by/3.0/au/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-3.0-DE.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-DE.json",
+      "referenceNumber": 458,
+      "name": "Creative Commons Attribution 3.0 Germany",
+      "licenseId": "CC-BY-3.0-DE",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by/3.0/de/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-3.0-IGO.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-IGO.json",
+      "referenceNumber": 410,
+      "name": "Creative Commons Attribution 3.0 IGO",
+      "licenseId": "CC-BY-3.0-IGO",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by/3.0/igo/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-3.0-NL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-NL.json",
+      "referenceNumber": 436,
+      "name": "Creative Commons Attribution 3.0 Netherlands",
+      "licenseId": "CC-BY-3.0-NL",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by/3.0/nl/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-3.0-US.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-US.json",
+      "referenceNumber": 366,
+      "name": "Creative Commons Attribution 3.0 United States",
+      "licenseId": "CC-BY-3.0-US",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by/3.0/us/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-4.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-4.0.json",
+      "referenceNumber": 66,
       "name": "Creative Commons Attribution 4.0 International",
       "licenseId": "CC-BY-4.0",
       "seeAlso": [
         "https://creativecommons.org/licenses/by/4.0/legalcode"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": false,
+      "isFsfLibre": true
     },
     {
-      "reference": "./CC-BY-NC-1.0.html",
+      "reference": "https://spdx.org/licenses/CC-BY-NC-1.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-1.0.json",
-      "referenceNumber": "215",
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-1.0.json",
+      "referenceNumber": 428,
       "name": "Creative Commons Attribution Non Commercial 1.0 Generic",
       "licenseId": "CC-BY-NC-1.0",
       "seeAlso": [
         "https://creativecommons.org/licenses/by-nc/1.0/legalcode"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": false,
+      "isFsfLibre": false
     },
     {
-      "reference": "./CC-BY-NC-2.0.html",
+      "reference": "https://spdx.org/licenses/CC-BY-NC-2.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-2.0.json",
-      "referenceNumber": "304",
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-2.0.json",
+      "referenceNumber": 553,
       "name": "Creative Commons Attribution Non Commercial 2.0 Generic",
       "licenseId": "CC-BY-NC-2.0",
       "seeAlso": [
         "https://creativecommons.org/licenses/by-nc/2.0/legalcode"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": false,
+      "isFsfLibre": false
     },
     {
-      "reference": "./CC-BY-NC-2.5.html",
+      "reference": "https://spdx.org/licenses/CC-BY-NC-2.5.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-2.5.json",
-      "referenceNumber": "374",
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-2.5.json",
+      "referenceNumber": 49,
       "name": "Creative Commons Attribution Non Commercial 2.5 Generic",
       "licenseId": "CC-BY-NC-2.5",
       "seeAlso": [
         "https://creativecommons.org/licenses/by-nc/2.5/legalcode"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": false,
+      "isFsfLibre": false
     },
     {
-      "reference": "./CC-BY-NC-3.0.html",
+      "reference": "https://spdx.org/licenses/CC-BY-NC-3.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-3.0.json",
-      "referenceNumber": "314",
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-3.0.json",
+      "referenceNumber": 686,
       "name": "Creative Commons Attribution Non Commercial 3.0 Unported",
       "licenseId": "CC-BY-NC-3.0",
       "seeAlso": [
         "https://creativecommons.org/licenses/by-nc/3.0/legalcode"
       ],
+      "isOsiApproved": false,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-3.0-DE.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-3.0-DE.json",
+      "referenceNumber": 324,
+      "name": "Creative Commons Attribution Non Commercial 3.0 Germany",
+      "licenseId": "CC-BY-NC-3.0-DE",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc/3.0/de/legalcode"
+      ],
       "isOsiApproved": false
     },
     {
-      "reference": "./CC-BY-NC-4.0.html",
+      "reference": "https://spdx.org/licenses/CC-BY-NC-4.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-4.0.json",
-      "referenceNumber": "252",
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-4.0.json",
+      "referenceNumber": 560,
       "name": "Creative Commons Attribution Non Commercial 4.0 International",
       "licenseId": "CC-BY-NC-4.0",
       "seeAlso": [
         "https://creativecommons.org/licenses/by-nc/4.0/legalcode"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": false,
+      "isFsfLibre": false
     },
     {
-      "reference": "./CC-BY-NC-ND-1.0.html",
+      "reference": "https://spdx.org/licenses/CC-BY-NC-ND-1.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-1.0.json",
-      "referenceNumber": "92",
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-1.0.json",
+      "referenceNumber": 442,
       "name": "Creative Commons Attribution Non Commercial No Derivatives 1.0 Generic",
       "licenseId": "CC-BY-NC-ND-1.0",
       "seeAlso": [
@@ -911,10 +1670,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./CC-BY-NC-ND-2.0.html",
+      "reference": "https://spdx.org/licenses/CC-BY-NC-ND-2.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-2.0.json",
-      "referenceNumber": "127",
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-2.0.json",
+      "referenceNumber": 334,
       "name": "Creative Commons Attribution Non Commercial No Derivatives 2.0 Generic",
       "licenseId": "CC-BY-NC-ND-2.0",
       "seeAlso": [
@@ -923,10 +1682,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./CC-BY-NC-ND-2.5.html",
+      "reference": "https://spdx.org/licenses/CC-BY-NC-ND-2.5.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-2.5.json",
-      "referenceNumber": "28",
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-2.5.json",
+      "referenceNumber": 215,
       "name": "Creative Commons Attribution Non Commercial No Derivatives 2.5 Generic",
       "licenseId": "CC-BY-NC-ND-2.5",
       "seeAlso": [
@@ -935,10 +1694,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./CC-BY-NC-ND-3.0.html",
+      "reference": "https://spdx.org/licenses/CC-BY-NC-ND-3.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-3.0.json",
-      "referenceNumber": "39",
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-3.0.json",
+      "referenceNumber": 94,
       "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 Unported",
       "licenseId": "CC-BY-NC-ND-3.0",
       "seeAlso": [
@@ -947,10 +1706,34 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./CC-BY-NC-ND-4.0.html",
+      "reference": "https://spdx.org/licenses/CC-BY-NC-ND-3.0-DE.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-4.0.json",
-      "referenceNumber": "160",
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-3.0-DE.json",
+      "referenceNumber": 185,
+      "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 Germany",
+      "licenseId": "CC-BY-NC-ND-3.0-DE",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-nd/3.0/de/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-ND-3.0-IGO.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-3.0-IGO.json",
+      "referenceNumber": 577,
+      "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 IGO",
+      "licenseId": "CC-BY-NC-ND-3.0-IGO",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-nd/3.0/igo/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-ND-4.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-4.0.json",
+      "referenceNumber": 53,
       "name": "Creative Commons Attribution Non Commercial No Derivatives 4.0 International",
       "licenseId": "CC-BY-NC-ND-4.0",
       "seeAlso": [
@@ -959,10 +1742,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./CC-BY-NC-SA-1.0.html",
+      "reference": "https://spdx.org/licenses/CC-BY-NC-SA-1.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-1.0.json",
-      "referenceNumber": "110",
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-1.0.json",
+      "referenceNumber": 510,
       "name": "Creative Commons Attribution Non Commercial Share Alike 1.0 Generic",
       "licenseId": "CC-BY-NC-SA-1.0",
       "seeAlso": [
@@ -971,10 +1754,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./CC-BY-NC-SA-2.0.html",
+      "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-2.0.json",
-      "referenceNumber": "386",
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.0.json",
+      "referenceNumber": 199,
       "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 Generic",
       "licenseId": "CC-BY-NC-SA-2.0",
       "seeAlso": [
@@ -983,10 +1766,46 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./CC-BY-NC-SA-2.5.html",
+      "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-DE.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-2.5.json",
-      "referenceNumber": "200",
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-DE.json",
+      "referenceNumber": 356,
+      "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 Germany",
+      "licenseId": "CC-BY-NC-SA-2.0-DE",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-sa/2.0/de/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-FR.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-FR.json",
+      "referenceNumber": 301,
+      "name": "Creative Commons Attribution-NonCommercial-ShareAlike 2.0 France",
+      "licenseId": "CC-BY-NC-SA-2.0-FR",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-sa/2.0/fr/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-UK.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-UK.json",
+      "referenceNumber": 671,
+      "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 England and Wales",
+      "licenseId": "CC-BY-NC-SA-2.0-UK",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-sa/2.0/uk/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.5.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.5.json",
+      "referenceNumber": 659,
       "name": "Creative Commons Attribution Non Commercial Share Alike 2.5 Generic",
       "licenseId": "CC-BY-NC-SA-2.5",
       "seeAlso": [
@@ -995,10 +1814,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./CC-BY-NC-SA-3.0.html",
+      "reference": "https://spdx.org/licenses/CC-BY-NC-SA-3.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-3.0.json",
-      "referenceNumber": "337",
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-3.0.json",
+      "referenceNumber": 359,
       "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 Unported",
       "licenseId": "CC-BY-NC-SA-3.0",
       "seeAlso": [
@@ -1007,10 +1826,34 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./CC-BY-NC-SA-4.0.html",
+      "reference": "https://spdx.org/licenses/CC-BY-NC-SA-3.0-DE.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-4.0.json",
-      "referenceNumber": "309",
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-3.0-DE.json",
+      "referenceNumber": 279,
+      "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 Germany",
+      "licenseId": "CC-BY-NC-SA-3.0-DE",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-sa/3.0/de/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-SA-3.0-IGO.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-3.0-IGO.json",
+      "referenceNumber": 636,
+      "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 IGO",
+      "licenseId": "CC-BY-NC-SA-3.0-IGO",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-sa/3.0/igo/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-NC-SA-4.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-4.0.json",
+      "referenceNumber": 89,
       "name": "Creative Commons Attribution Non Commercial Share Alike 4.0 International",
       "licenseId": "CC-BY-NC-SA-4.0",
       "seeAlso": [
@@ -1019,70 +1862,87 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./CC-BY-ND-1.0.html",
+      "reference": "https://spdx.org/licenses/CC-BY-ND-1.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-1.0.json",
-      "referenceNumber": "85",
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-1.0.json",
+      "referenceNumber": 118,
       "name": "Creative Commons Attribution No Derivatives 1.0 Generic",
       "licenseId": "CC-BY-ND-1.0",
       "seeAlso": [
         "https://creativecommons.org/licenses/by-nd/1.0/legalcode"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": false,
+      "isFsfLibre": false
     },
     {
-      "reference": "./CC-BY-ND-2.0.html",
+      "reference": "https://spdx.org/licenses/CC-BY-ND-2.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-2.0.json",
-      "referenceNumber": "43",
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-2.0.json",
+      "referenceNumber": 587,
       "name": "Creative Commons Attribution No Derivatives 2.0 Generic",
       "licenseId": "CC-BY-ND-2.0",
       "seeAlso": [
         "https://creativecommons.org/licenses/by-nd/2.0/legalcode"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": false,
+      "isFsfLibre": false
     },
     {
-      "reference": "./CC-BY-ND-2.5.html",
+      "reference": "https://spdx.org/licenses/CC-BY-ND-2.5.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-2.5.json",
-      "referenceNumber": "25",
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-2.5.json",
+      "referenceNumber": 394,
       "name": "Creative Commons Attribution No Derivatives 2.5 Generic",
       "licenseId": "CC-BY-ND-2.5",
       "seeAlso": [
         "https://creativecommons.org/licenses/by-nd/2.5/legalcode"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": false,
+      "isFsfLibre": false
     },
     {
-      "reference": "./CC-BY-ND-3.0.html",
+      "reference": "https://spdx.org/licenses/CC-BY-ND-3.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-3.0.json",
-      "referenceNumber": "264",
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-3.0.json",
+      "referenceNumber": 457,
       "name": "Creative Commons Attribution No Derivatives 3.0 Unported",
       "licenseId": "CC-BY-ND-3.0",
       "seeAlso": [
         "https://creativecommons.org/licenses/by-nd/3.0/legalcode"
       ],
+      "isOsiApproved": false,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-ND-3.0-DE.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-3.0-DE.json",
+      "referenceNumber": 610,
+      "name": "Creative Commons Attribution No Derivatives 3.0 Germany",
+      "licenseId": "CC-BY-ND-3.0-DE",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nd/3.0/de/legalcode"
+      ],
       "isOsiApproved": false
     },
     {
-      "reference": "./CC-BY-ND-4.0.html",
+      "reference": "https://spdx.org/licenses/CC-BY-ND-4.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-4.0.json",
-      "referenceNumber": "296",
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-4.0.json",
+      "referenceNumber": 11,
       "name": "Creative Commons Attribution No Derivatives 4.0 International",
       "licenseId": "CC-BY-ND-4.0",
       "seeAlso": [
         "https://creativecommons.org/licenses/by-nd/4.0/legalcode"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": false,
+      "isFsfLibre": false
     },
     {
-      "reference": "./CC-BY-SA-1.0.html",
+      "reference": "https://spdx.org/licenses/CC-BY-SA-1.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-1.0.json",
-      "referenceNumber": "379",
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-1.0.json",
+      "referenceNumber": 384,
       "name": "Creative Commons Attribution Share Alike 1.0 Generic",
       "licenseId": "CC-BY-SA-1.0",
       "seeAlso": [
@@ -1091,10 +1951,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./CC-BY-SA-2.0.html",
+      "reference": "https://spdx.org/licenses/CC-BY-SA-2.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-2.0.json",
-      "referenceNumber": "344",
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-2.0.json",
+      "referenceNumber": 260,
       "name": "Creative Commons Attribution Share Alike 2.0 Generic",
       "licenseId": "CC-BY-SA-2.0",
       "seeAlso": [
@@ -1103,10 +1963,34 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./CC-BY-SA-2.5.html",
+      "reference": "https://spdx.org/licenses/CC-BY-SA-2.0-UK.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-2.5.json",
-      "referenceNumber": "189",
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-2.0-UK.json",
+      "referenceNumber": 197,
+      "name": "Creative Commons Attribution Share Alike 2.0 England and Wales",
+      "licenseId": "CC-BY-SA-2.0-UK",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-sa/2.0/uk/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-SA-2.1-JP.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-2.1-JP.json",
+      "referenceNumber": 149,
+      "name": "Creative Commons Attribution Share Alike 2.1 Japan",
+      "licenseId": "CC-BY-SA-2.1-JP",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-sa/2.1/jp/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-SA-2.5.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-2.5.json",
+      "referenceNumber": 631,
       "name": "Creative Commons Attribution Share Alike 2.5 Generic",
       "licenseId": "CC-BY-SA-2.5",
       "seeAlso": [
@@ -1115,10 +1999,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./CC-BY-SA-3.0.html",
+      "reference": "https://spdx.org/licenses/CC-BY-SA-3.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-3.0.json",
-      "referenceNumber": "217",
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-3.0.json",
+      "referenceNumber": 79,
       "name": "Creative Commons Attribution Share Alike 3.0 Unported",
       "licenseId": "CC-BY-SA-3.0",
       "seeAlso": [
@@ -1127,23 +2011,59 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./CC-BY-SA-4.0.html",
+      "reference": "https://spdx.org/licenses/CC-BY-SA-3.0-AT.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-4.0.json",
-      "referenceNumber": "276",
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-3.0-AT.json",
+      "referenceNumber": 493,
+      "name": "Creative Commons Attribution Share Alike 3.0 Austria",
+      "licenseId": "CC-BY-SA-3.0-AT",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-sa/3.0/at/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-SA-3.0-DE.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-3.0-DE.json",
+      "referenceNumber": 683,
+      "name": "Creative Commons Attribution Share Alike 3.0 Germany",
+      "licenseId": "CC-BY-SA-3.0-DE",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-sa/3.0/de/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-SA-3.0-IGO.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-3.0-IGO.json",
+      "referenceNumber": 571,
+      "name": "Creative Commons Attribution-ShareAlike 3.0 IGO",
+      "licenseId": "CC-BY-SA-3.0-IGO",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-sa/3.0/igo/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-BY-SA-4.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-4.0.json",
+      "referenceNumber": 256,
       "name": "Creative Commons Attribution Share Alike 4.0 International",
       "licenseId": "CC-BY-SA-4.0",
       "seeAlso": [
         "https://creativecommons.org/licenses/by-sa/4.0/legalcode"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": false,
+      "isFsfLibre": true
     },
     {
-      "reference": "./CC-PDDC.html",
+      "reference": "https://spdx.org/licenses/CC-PDDC.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CC-PDDC.json",
-      "referenceNumber": "83",
+      "detailsUrl": "https://spdx.org/licenses/CC-PDDC.json",
+      "referenceNumber": 273,
       "name": "Creative Commons Public Domain Dedication and Certification",
       "licenseId": "CC-PDDC",
       "seeAlso": [
@@ -1152,36 +2072,61 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./CC0-1.0.html",
+      "reference": "https://spdx.org/licenses/CC-PDM-1.0.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/CC0-1.0.json",
-      "referenceNumber": "60",
+      "detailsUrl": "https://spdx.org/licenses/CC-PDM-1.0.json",
+      "referenceNumber": 547,
+      "name": "Creative    Commons Public Domain Mark 1.0 Universal",
+      "licenseId": "CC-PDM-1.0",
+      "seeAlso": [
+        "https://creativecommons.org/publicdomain/mark/1.0/",
+        "https://creativecommons.org/share-your-work/cclicenses/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC-SA-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC-SA-1.0.json",
+      "referenceNumber": 85,
+      "name": "Creative Commons Share Alike 1.0 Generic",
+      "licenseId": "CC-SA-1.0",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/sa/1.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CC0-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CC0-1.0.json",
+      "referenceNumber": 369,
       "name": "Creative Commons Zero v1.0 Universal",
       "licenseId": "CC0-1.0",
       "seeAlso": [
         "https://creativecommons.org/publicdomain/zero/1.0/legalcode"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": false,
+      "isFsfLibre": true
     },
     {
-      "reference": "./CDDL-1.0.html",
+      "reference": "https://spdx.org/licenses/CDDL-1.0.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/CDDL-1.0.json",
-      "referenceNumber": "313",
+      "detailsUrl": "https://spdx.org/licenses/CDDL-1.0.json",
+      "referenceNumber": 407,
       "name": "Common Development and Distribution License 1.0",
       "licenseId": "CDDL-1.0",
       "seeAlso": [
         "https://opensource.org/licenses/cddl1"
       ],
-      "isOsiApproved": true
+      "isOsiApproved": true,
+      "isFsfLibre": true
     },
     {
-      "reference": "./CDDL-1.1.html",
+      "reference": "https://spdx.org/licenses/CDDL-1.1.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CDDL-1.1.json",
-      "referenceNumber": "263",
+      "detailsUrl": "https://spdx.org/licenses/CDDL-1.1.json",
+      "referenceNumber": 124,
       "name": "Common Development and Distribution License 1.1",
       "licenseId": "CDDL-1.1",
       "seeAlso": [
@@ -1191,10 +2136,24 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./CDLA-Permissive-1.0.html",
+      "reference": "https://spdx.org/licenses/CDL-1.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CDLA-Permissive-1.0.json",
-      "referenceNumber": "98",
+      "detailsUrl": "https://spdx.org/licenses/CDL-1.0.json",
+      "referenceNumber": 385,
+      "name": "Common Documentation License 1.0",
+      "licenseId": "CDL-1.0",
+      "seeAlso": [
+        "http://www.opensource.apple.com/cdl/",
+        "https://fedoraproject.org/wiki/Licensing/Common_Documentation_License",
+        "https://www.gnu.org/licenses/license-list.html#ACDL"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CDLA-Permissive-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CDLA-Permissive-1.0.json",
+      "referenceNumber": 454,
       "name": "Community Data License Agreement Permissive 1.0",
       "licenseId": "CDLA-Permissive-1.0",
       "seeAlso": [
@@ -1203,10 +2162,22 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./CDLA-Sharing-1.0.html",
+      "reference": "https://spdx.org/licenses/CDLA-Permissive-2.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CDLA-Sharing-1.0.json",
-      "referenceNumber": "166",
+      "detailsUrl": "https://spdx.org/licenses/CDLA-Permissive-2.0.json",
+      "referenceNumber": 520,
+      "name": "Community Data License Agreement Permissive 2.0",
+      "licenseId": "CDLA-Permissive-2.0",
+      "seeAlso": [
+        "https://cdla.dev/permissive-2-0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CDLA-Sharing-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CDLA-Sharing-1.0.json",
+      "referenceNumber": 548,
       "name": "Community Data License Agreement Sharing 1.0",
       "licenseId": "CDLA-Sharing-1.0",
       "seeAlso": [
@@ -1215,10 +2186,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./CECILL-1.0.html",
+      "reference": "https://spdx.org/licenses/CECILL-1.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CECILL-1.0.json",
-      "referenceNumber": "10",
+      "detailsUrl": "https://spdx.org/licenses/CECILL-1.0.json",
+      "referenceNumber": 468,
       "name": "CeCILL Free Software License Agreement v1.0",
       "licenseId": "CECILL-1.0",
       "seeAlso": [
@@ -1227,10 +2198,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./CECILL-1.1.html",
+      "reference": "https://spdx.org/licenses/CECILL-1.1.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CECILL-1.1.json",
-      "referenceNumber": "124",
+      "detailsUrl": "https://spdx.org/licenses/CECILL-1.1.json",
+      "referenceNumber": 100,
       "name": "CeCILL Free Software License Agreement v1.1",
       "licenseId": "CECILL-1.1",
       "seeAlso": [
@@ -1239,23 +2210,23 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./CECILL-2.0.html",
+      "reference": "https://spdx.org/licenses/CECILL-2.0.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/CECILL-2.0.json",
-      "referenceNumber": "5",
+      "detailsUrl": "https://spdx.org/licenses/CECILL-2.0.json",
+      "referenceNumber": 370,
       "name": "CeCILL Free Software License Agreement v2.0",
       "licenseId": "CECILL-2.0",
       "seeAlso": [
         "http://www.cecill.info/licences/Licence_CeCILL_V2-en.html"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": false,
+      "isFsfLibre": true
     },
     {
-      "reference": "./CECILL-2.1.html",
+      "reference": "https://spdx.org/licenses/CECILL-2.1.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CECILL-2.1.json",
-      "referenceNumber": "134",
+      "detailsUrl": "https://spdx.org/licenses/CECILL-2.1.json",
+      "referenceNumber": 95,
       "name": "CeCILL Free Software License Agreement v2.1",
       "licenseId": "CECILL-2.1",
       "seeAlso": [
@@ -1264,36 +2235,36 @@
       "isOsiApproved": true
     },
     {
-      "reference": "./CECILL-B.html",
+      "reference": "https://spdx.org/licenses/CECILL-B.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/CECILL-B.json",
-      "referenceNumber": "84",
+      "detailsUrl": "https://spdx.org/licenses/CECILL-B.json",
+      "referenceNumber": 425,
       "name": "CeCILL-B Free Software License Agreement",
       "licenseId": "CECILL-B",
       "seeAlso": [
         "http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.html"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": false,
+      "isFsfLibre": true
     },
     {
-      "reference": "./CECILL-C.html",
+      "reference": "https://spdx.org/licenses/CECILL-C.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/CECILL-C.json",
-      "referenceNumber": "224",
+      "detailsUrl": "https://spdx.org/licenses/CECILL-C.json",
+      "referenceNumber": 45,
       "name": "CeCILL-C Free Software License Agreement",
       "licenseId": "CECILL-C",
       "seeAlso": [
         "http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.html"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": false,
+      "isFsfLibre": true
     },
     {
-      "reference": "./CERN-OHL-1.1.html",
+      "reference": "https://spdx.org/licenses/CERN-OHL-1.1.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CERN-OHL-1.1.json",
-      "referenceNumber": "112",
+      "detailsUrl": "https://spdx.org/licenses/CERN-OHL-1.1.json",
+      "referenceNumber": 398,
       "name": "CERN Open Hardware Licence v1.1",
       "licenseId": "CERN-OHL-1.1",
       "seeAlso": [
@@ -1302,10 +2273,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./CERN-OHL-1.2.html",
+      "reference": "https://spdx.org/licenses/CERN-OHL-1.2.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CERN-OHL-1.2.json",
-      "referenceNumber": "155",
+      "detailsUrl": "https://spdx.org/licenses/CERN-OHL-1.2.json",
+      "referenceNumber": 318,
       "name": "CERN Open Hardware Licence v1.2",
       "licenseId": "CERN-OHL-1.2",
       "seeAlso": [
@@ -1314,10 +2285,134 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./CNRI-Jython.html",
+      "reference": "https://spdx.org/licenses/CERN-OHL-P-2.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CNRI-Jython.json",
-      "referenceNumber": "69",
+      "detailsUrl": "https://spdx.org/licenses/CERN-OHL-P-2.0.json",
+      "referenceNumber": 200,
+      "name": "CERN Open Hardware Licence Version 2 - Permissive",
+      "licenseId": "CERN-OHL-P-2.0",
+      "seeAlso": [
+        "https://www.ohwr.org/project/cernohl/wikis/Documents/CERN-OHL-version-2"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CERN-OHL-S-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CERN-OHL-S-2.0.json",
+      "referenceNumber": 175,
+      "name": "CERN Open Hardware Licence Version 2 - Strongly Reciprocal",
+      "licenseId": "CERN-OHL-S-2.0",
+      "seeAlso": [
+        "https://www.ohwr.org/project/cernohl/wikis/Documents/CERN-OHL-version-2"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CERN-OHL-W-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CERN-OHL-W-2.0.json",
+      "referenceNumber": 219,
+      "name": "CERN Open Hardware Licence Version 2 - Weakly Reciprocal",
+      "licenseId": "CERN-OHL-W-2.0",
+      "seeAlso": [
+        "https://www.ohwr.org/project/cernohl/wikis/Documents/CERN-OHL-version-2"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CFITSIO.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CFITSIO.json",
+      "referenceNumber": 207,
+      "name": "CFITSIO License",
+      "licenseId": "CFITSIO",
+      "seeAlso": [
+        "https://heasarc.gsfc.nasa.gov/docs/software/fitsio/c/f_user/node9.html",
+        "https://heasarc.gsfc.nasa.gov/docs/software/ftools/fv/doc/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/check-cvs.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/check-cvs.json",
+      "referenceNumber": 377,
+      "name": "check-cvs License",
+      "licenseId": "check-cvs",
+      "seeAlso": [
+        "http://cvs.savannah.gnu.org/viewvc/cvs/ccvs/contrib/check_cvs.in?revision\u003d1.1.4.3\u0026view\u003dmarkup\u0026pathrev\u003dcvs1-11-23#l2"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/checkmk.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/checkmk.json",
+      "referenceNumber": 389,
+      "name": "Checkmk License",
+      "licenseId": "checkmk",
+      "seeAlso": [
+        "https://github.com/libcheck/check/blob/master/checkmk/checkmk.in"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/ClArtistic.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ClArtistic.json",
+      "referenceNumber": 690,
+      "name": "Clarified Artistic License",
+      "licenseId": "ClArtistic",
+      "seeAlso": [
+        "http://gianluca.dellavedova.org/2011/01/03/clarified-artistic-license/",
+        "http://www.ncftp.com/ncftp/doc/LICENSE.txt"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Clips.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Clips.json",
+      "referenceNumber": 65,
+      "name": "Clips License",
+      "licenseId": "Clips",
+      "seeAlso": [
+        "https://github.com/DrItanium/maya/blob/master/LICENSE.CLIPS"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CMU-Mach.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CMU-Mach.json",
+      "referenceNumber": 178,
+      "name": "CMU Mach License",
+      "licenseId": "CMU-Mach",
+      "seeAlso": [
+        "https://www.cs.cmu.edu/~410/licenses.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CMU-Mach-nodoc.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CMU-Mach-nodoc.json",
+      "referenceNumber": 391,
+      "name": "CMU    Mach - no notices-in-documentation variant",
+      "licenseId": "CMU-Mach-nodoc",
+      "seeAlso": [
+        "https://github.com/krb5/krb5/blob/krb5-1.21.2-final/NOTICE#L718-L728",
+        "https://web.mit.edu/kerberos/krb5-1.21/doc/mitK5license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CNRI-Jython.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CNRI-Jython.json",
+      "referenceNumber": 138,
       "name": "CNRI Jython License",
       "licenseId": "CNRI-Jython",
       "seeAlso": [
@@ -1326,10 +2421,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./CNRI-Python.html",
+      "reference": "https://spdx.org/licenses/CNRI-Python.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CNRI-Python.json",
-      "referenceNumber": "86",
+      "detailsUrl": "https://spdx.org/licenses/CNRI-Python.json",
+      "referenceNumber": 352,
       "name": "CNRI Python License",
       "licenseId": "CNRI-Python",
       "seeAlso": [
@@ -1338,10 +2433,10 @@
       "isOsiApproved": true
     },
     {
-      "reference": "./CNRI-Python-GPL-Compatible.html",
+      "reference": "https://spdx.org/licenses/CNRI-Python-GPL-Compatible.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CNRI-Python-GPL-Compatible.json",
-      "referenceNumber": "326",
+      "detailsUrl": "https://spdx.org/licenses/CNRI-Python-GPL-Compatible.json",
+      "referenceNumber": 673,
       "name": "CNRI Python Open Source GPL Compatible License Agreement",
       "licenseId": "CNRI-Python-GPL-Compatible",
       "seeAlso": [
@@ -1350,100 +2445,140 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./CPAL-1.0.html",
+      "reference": "https://spdx.org/licenses/COIL-1.0.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/CPAL-1.0.json",
-      "referenceNumber": "265",
-      "name": "Common Public Attribution License 1.0",
-      "licenseId": "CPAL-1.0",
+      "detailsUrl": "https://spdx.org/licenses/COIL-1.0.json",
+      "referenceNumber": 526,
+      "name": "Copyfree Open Innovation License",
+      "licenseId": "COIL-1.0",
       "seeAlso": [
-        "https://opensource.org/licenses/CPAL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./CPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/CPL-1.0.json",
-      "referenceNumber": "220",
-      "name": "Common Public License 1.0",
-      "licenseId": "CPL-1.0",
-      "seeAlso": [
-        "https://opensource.org/licenses/CPL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./CPOL-1.02.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CPOL-1.02.json",
-      "referenceNumber": "214",
-      "name": "Code Project Open License 1.02",
-      "licenseId": "CPOL-1.02",
-      "seeAlso": [
-        "http://www.codeproject.com/info/cpol10.aspx"
+        "https://coil.apotheon.org/plaintext/01.0.txt"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./CUA-OPL-1.0.html",
+      "reference": "https://spdx.org/licenses/Community-Spec-1.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CUA-OPL-1.0.json",
-      "referenceNumber": "153",
-      "name": "CUA Office Public License v1.0",
-      "licenseId": "CUA-OPL-1.0",
+      "detailsUrl": "https://spdx.org/licenses/Community-Spec-1.0.json",
+      "referenceNumber": 695,
+      "name": "Community Specification License 1.0",
+      "licenseId": "Community-Spec-1.0",
       "seeAlso": [
-        "https://opensource.org/licenses/CUA-OPL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Caldera.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Caldera.json",
-      "referenceNumber": "233",
-      "name": "Caldera License",
-      "licenseId": "Caldera",
-      "seeAlso": [
-        "http://www.lemis.com/grog/UNIX/ancient-source-all.pdf"
+        "https://github.com/CommunitySpecification/1.0/blob/master/1._Community_Specification_License-v1.md"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./ClArtistic.html",
+      "reference": "https://spdx.org/licenses/Condor-1.1.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/ClArtistic.json",
-      "referenceNumber": "229",
-      "name": "Clarified Artistic License",
-      "licenseId": "ClArtistic",
-      "seeAlso": [
-        "http://gianluca.dellavedova.org/2011/01/03/clarified-artistic-license/",
-        "http://www.ncftp.com/ncftp/doc/LICENSE.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Condor-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Condor-1.1.json",
-      "referenceNumber": "139",
+      "detailsUrl": "https://spdx.org/licenses/Condor-1.1.json",
+      "referenceNumber": 114,
       "name": "Condor Public License v1.1",
       "licenseId": "Condor-1.1",
       "seeAlso": [
         "http://research.cs.wisc.edu/condor/license.html#condor",
         "http://web.archive.org/web/20111123062036/http://research.cs.wisc.edu/condor/license.html#condor"
       ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/copyleft-next-0.3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/copyleft-next-0.3.0.json",
+      "referenceNumber": 122,
+      "name": "copyleft-next 0.3.0",
+      "licenseId": "copyleft-next-0.3.0",
+      "seeAlso": [
+        "https://github.com/copyleft-next/copyleft-next/blob/master/Releases/copyleft-next-0.3.0"
+      ],
       "isOsiApproved": false
     },
     {
-      "reference": "./Crossword.html",
+      "reference": "https://spdx.org/licenses/copyleft-next-0.3.1.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Crossword.json",
-      "referenceNumber": "91",
+      "detailsUrl": "https://spdx.org/licenses/copyleft-next-0.3.1.json",
+      "referenceNumber": 583,
+      "name": "copyleft-next 0.3.1",
+      "licenseId": "copyleft-next-0.3.1",
+      "seeAlso": [
+        "https://github.com/copyleft-next/copyleft-next/blob/master/Releases/copyleft-next-0.3.1"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Cornell-Lossless-JPEG.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Cornell-Lossless-JPEG.json",
+      "referenceNumber": 331,
+      "name": "Cornell Lossless JPEG License",
+      "licenseId": "Cornell-Lossless-JPEG",
+      "seeAlso": [
+        "https://android.googlesource.com/platform/external/dng_sdk/+/refs/heads/master/source/dng_lossless_jpeg.cpp#16",
+        "https://www.mssl.ucl.ac.uk/~mcrw/src/20050920/proto.h",
+        "https://gitlab.freedesktop.org/libopenraw/libopenraw/blob/master/lib/ljpegdecompressor.cpp#L32"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CPAL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CPAL-1.0.json",
+      "referenceNumber": 147,
+      "name": "Common Public Attribution License 1.0",
+      "licenseId": "CPAL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/CPAL-1.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CPL-1.0.json",
+      "referenceNumber": 367,
+      "name": "Common Public License 1.0",
+      "licenseId": "CPL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/CPL-1.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/CPOL-1.02.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CPOL-1.02.json",
+      "referenceNumber": 250,
+      "name": "Code Project Open License 1.02",
+      "licenseId": "CPOL-1.02",
+      "seeAlso": [
+        "http://www.codeproject.com/info/cpol10.aspx"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Cronyx.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Cronyx.json",
+      "referenceNumber": 32,
+      "name": "Cronyx License",
+      "licenseId": "Cronyx",
+      "seeAlso": [
+        "https://gitlab.freedesktop.org/xorg/font/alias/-/blob/master/COPYING",
+        "https://gitlab.freedesktop.org/xorg/font/cronyx-cyrillic/-/blob/master/COPYING",
+        "https://gitlab.freedesktop.org/xorg/font/misc-cyrillic/-/blob/master/COPYING",
+        "https://gitlab.freedesktop.org/xorg/font/screen-cyrillic/-/blob/master/COPYING"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Crossword.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Crossword.json",
+      "referenceNumber": 347,
       "name": "Crossword License",
       "licenseId": "Crossword",
       "seeAlso": [
@@ -1452,10 +2587,22 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./CrystalStacker.html",
+      "reference": "https://spdx.org/licenses/CryptoSwift.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CrystalStacker.json",
-      "referenceNumber": "36",
+      "detailsUrl": "https://spdx.org/licenses/CryptoSwift.json",
+      "referenceNumber": 323,
+      "name": "CryptoSwift License",
+      "licenseId": "CryptoSwift",
+      "seeAlso": [
+        "https://github.com/krzyzanowskim/CryptoSwift/blob/main/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/CrystalStacker.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/CrystalStacker.json",
+      "referenceNumber": 449,
       "name": "CrystalStacker License",
       "licenseId": "CrystalStacker",
       "seeAlso": [
@@ -1464,10 +2611,22 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./Cube.html",
+      "reference": "https://spdx.org/licenses/CUA-OPL-1.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Cube.json",
-      "referenceNumber": "367",
+      "detailsUrl": "https://spdx.org/licenses/CUA-OPL-1.0.json",
+      "referenceNumber": 298,
+      "name": "CUA Office Public License v1.0",
+      "licenseId": "CUA-OPL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/CUA-OPL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Cube.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Cube.json",
+      "referenceNumber": 140,
       "name": "Cube License",
       "licenseId": "Cube",
       "seeAlso": [
@@ -1476,10 +2635,34 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./D-FSL-1.0.html",
+      "reference": "https://spdx.org/licenses/curl.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/D-FSL-1.0.json",
-      "referenceNumber": "335",
+      "detailsUrl": "https://spdx.org/licenses/curl.json",
+      "referenceNumber": 160,
+      "name": "curl License",
+      "licenseId": "curl",
+      "seeAlso": [
+        "https://github.com/bagder/curl/blob/master/COPYING"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/cve-tou.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/cve-tou.json",
+      "referenceNumber": 216,
+      "name": "Common Vulnerability Enumeration ToU License",
+      "licenseId": "cve-tou",
+      "seeAlso": [
+        "https://www.cve.org/Legal/TermsOfUse"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/D-FSL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/D-FSL-1.0.json",
+      "referenceNumber": 545,
       "name": "Deutsche Freie Software Lizenz",
       "licenseId": "D-FSL-1.0",
       "seeAlso": [
@@ -1495,34 +2678,119 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./DOC.html",
+      "reference": "https://spdx.org/licenses/DEC-3-Clause.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/DOC.json",
-      "referenceNumber": "255",
+      "detailsUrl": "https://spdx.org/licenses/DEC-3-Clause.json",
+      "referenceNumber": 164,
+      "name": "DEC 3-Clause License",
+      "licenseId": "DEC-3-Clause",
+      "seeAlso": [
+        "https://gitlab.freedesktop.org/xorg/xserver/-/blob/master/COPYING?ref_type\u003dheads#L239"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/diffmark.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/diffmark.json",
+      "referenceNumber": 50,
+      "name": "diffmark license",
+      "licenseId": "diffmark",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/diffmark"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/DL-DE-BY-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/DL-DE-BY-2.0.json",
+      "referenceNumber": 530,
+      "name": "Data licence Germany – attribution – version 2.0",
+      "licenseId": "DL-DE-BY-2.0",
+      "seeAlso": [
+        "https://www.govdata.de/dl-de/by-2-0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/DL-DE-ZERO-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/DL-DE-ZERO-2.0.json",
+      "referenceNumber": 139,
+      "name": "Data licence Germany – zero – version 2.0",
+      "licenseId": "DL-DE-ZERO-2.0",
+      "seeAlso": [
+        "https://www.govdata.de/dl-de/zero-2-0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/DOC.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/DOC.json",
+      "referenceNumber": 31,
       "name": "DOC License",
       "licenseId": "DOC",
       "seeAlso": [
-        "http://www.cs.wustl.edu/~schmidt/ACE-copying.html"
+        "http://www.cs.wustl.edu/~schmidt/ACE-copying.html",
+        "https://www.dre.vanderbilt.edu/~schmidt/ACE-copying.html"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./DSDP.html",
+      "reference": "https://spdx.org/licenses/DocBook-DTD.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/DSDP.json",
-      "referenceNumber": "248",
-      "name": "DSDP License",
-      "licenseId": "DSDP",
+      "detailsUrl": "https://spdx.org/licenses/DocBook-DTD.json",
+      "referenceNumber": 603,
+      "name": "DocBook DTD License",
+      "licenseId": "DocBook-DTD",
       "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/DSDP"
+        "http://www.docbook.org/xml/simple/1.1/docbook-simple-1.1.zip"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./Dotseqn.html",
+      "reference": "https://spdx.org/licenses/DocBook-Schema.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Dotseqn.json",
-      "referenceNumber": "31",
+      "detailsUrl": "https://spdx.org/licenses/DocBook-Schema.json",
+      "referenceNumber": 184,
+      "name": "DocBook Schema License",
+      "licenseId": "DocBook-Schema",
+      "seeAlso": [
+        "https://github.com/docbook/xslt10-stylesheets/blob/efd62655c11cc8773708df7a843613fa1e932bf8/xsl/assembly/schema/docbook51b7.rnc"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/DocBook-Stylesheet.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/DocBook-Stylesheet.json",
+      "referenceNumber": 494,
+      "name": "DocBook Stylesheet License",
+      "licenseId": "DocBook-Stylesheet",
+      "seeAlso": [
+        "http://www.docbook.org/xml/5.0/docbook-5.0.zip"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/DocBook-XML.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/DocBook-XML.json",
+      "referenceNumber": 672,
+      "name": "DocBook XML License",
+      "licenseId": "DocBook-XML",
+      "seeAlso": [
+        "https://github.com/docbook/xslt10-stylesheets/blob/efd62655c11cc8773708df7a843613fa1e932bf8/xsl/COPYING#L27"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Dotseqn.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Dotseqn.json",
+      "referenceNumber": 257,
       "name": "Dotseqn License",
       "licenseId": "Dotseqn",
       "seeAlso": [
@@ -1531,10 +2799,71 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./ECL-1.0.html",
+      "reference": "https://spdx.org/licenses/DRL-1.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/ECL-1.0.json",
-      "referenceNumber": "393",
+      "detailsUrl": "https://spdx.org/licenses/DRL-1.0.json",
+      "referenceNumber": 446,
+      "name": "Detection Rule License 1.0",
+      "licenseId": "DRL-1.0",
+      "seeAlso": [
+        "https://github.com/Neo23x0/sigma/blob/master/LICENSE.Detection.Rules.md"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/DRL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/DRL-1.1.json",
+      "referenceNumber": 135,
+      "name": "Detection Rule License 1.1",
+      "licenseId": "DRL-1.1",
+      "seeAlso": [
+        "https://github.com/SigmaHQ/Detection-Rule-License/blob/6ec7fbde6101d101b5b5d1fcb8f9b69fbc76c04a/LICENSE.Detection.Rules.md"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/DSDP.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/DSDP.json",
+      "referenceNumber": 336,
+      "name": "DSDP License",
+      "licenseId": "DSDP",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/DSDP"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/dtoa.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/dtoa.json",
+      "referenceNumber": 578,
+      "name": "David M. Gay dtoa License",
+      "licenseId": "dtoa",
+      "seeAlso": [
+        "https://github.com/SWI-Prolog/swipl-devel/blob/master/src/os/dtoa.c",
+        "https://sourceware.org/git/?p\u003dnewlib-cygwin.git;a\u003dblob;f\u003dnewlib/libc/stdlib/mprec.h;hb\u003dHEAD"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/dvipdfm.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/dvipdfm.json",
+      "referenceNumber": 319,
+      "name": "dvipdfm License",
+      "licenseId": "dvipdfm",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/dvipdfm"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/ECL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ECL-1.0.json",
+      "referenceNumber": 641,
       "name": "Educational Community License v1.0",
       "licenseId": "ECL-1.0",
       "seeAlso": [
@@ -1543,23 +2872,36 @@
       "isOsiApproved": true
     },
     {
-      "reference": "./ECL-2.0.html",
+      "reference": "https://spdx.org/licenses/ECL-2.0.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/ECL-2.0.json",
-      "referenceNumber": "1",
+      "detailsUrl": "https://spdx.org/licenses/ECL-2.0.json",
+      "referenceNumber": 338,
       "name": "Educational Community License v2.0",
       "licenseId": "ECL-2.0",
       "seeAlso": [
         "https://opensource.org/licenses/ECL-2.0"
       ],
-      "isOsiApproved": true
+      "isOsiApproved": true,
+      "isFsfLibre": true
     },
     {
-      "reference": "./EFL-1.0.html",
+      "reference": "https://spdx.org/licenses/eCos-2.0.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/eCos-2.0.json",
+      "referenceNumber": 647,
+      "name": "eCos license version 2.0",
+      "licenseId": "eCos-2.0",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/ecos-license.html"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/EFL-1.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/EFL-1.0.json",
-      "referenceNumber": "68",
+      "detailsUrl": "https://spdx.org/licenses/EFL-1.0.json",
+      "referenceNumber": 145,
       "name": "Eiffel Forum License v1.0",
       "licenseId": "EFL-1.0",
       "seeAlso": [
@@ -1569,66 +2911,143 @@
       "isOsiApproved": true
     },
     {
-      "reference": "./EFL-2.0.html",
+      "reference": "https://spdx.org/licenses/EFL-2.0.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/EFL-2.0.json",
-      "referenceNumber": "7",
+      "detailsUrl": "https://spdx.org/licenses/EFL-2.0.json",
+      "referenceNumber": 604,
       "name": "Eiffel Forum License v2.0",
       "licenseId": "EFL-2.0",
       "seeAlso": [
         "http://www.eiffel-nice.org/license/eiffel-forum-license-2.html",
         "https://opensource.org/licenses/EFL-2.0"
       ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/eGenix.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/eGenix.json",
+      "referenceNumber": 613,
+      "name": "eGenix.com Public License 1.1.0",
+      "licenseId": "eGenix",
+      "seeAlso": [
+        "http://www.egenix.com/products/eGenix.com-Public-License-1.1.0.pdf",
+        "https://fedoraproject.org/wiki/Licensing/eGenix.com_Public_License_1.1.0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Elastic-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Elastic-2.0.json",
+      "referenceNumber": 396,
+      "name": "Elastic License 2.0",
+      "licenseId": "Elastic-2.0",
+      "seeAlso": [
+        "https://www.elastic.co/licensing/elastic-license",
+        "https://github.com/elastic/elasticsearch/blob/master/licenses/ELASTIC-LICENSE-2.0.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Entessa.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Entessa.json",
+      "referenceNumber": 40,
+      "name": "Entessa Public License v1.0",
+      "licenseId": "Entessa",
+      "seeAlso": [
+        "https://opensource.org/licenses/Entessa"
+      ],
       "isOsiApproved": true
     },
     {
-      "reference": "./EPL-1.0.html",
+      "reference": "https://spdx.org/licenses/EPICS.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/EPL-1.0.json",
-      "referenceNumber": "257",
+      "detailsUrl": "https://spdx.org/licenses/EPICS.json",
+      "referenceNumber": 158,
+      "name": "EPICS Open License",
+      "licenseId": "EPICS",
+      "seeAlso": [
+        "https://epics.anl.gov/license/open.php"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/EPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/EPL-1.0.json",
+      "referenceNumber": 558,
       "name": "Eclipse Public License 1.0",
       "licenseId": "EPL-1.0",
       "seeAlso": [
         "http://www.eclipse.org/legal/epl-v10.html",
         "https://opensource.org/licenses/EPL-1.0"
       ],
-      "isOsiApproved": true
+      "isOsiApproved": true,
+      "isFsfLibre": true
     },
     {
-      "reference": "./EPL-2.0.html",
+      "reference": "https://spdx.org/licenses/EPL-2.0.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/EPL-2.0.json",
-      "referenceNumber": "391",
+      "detailsUrl": "https://spdx.org/licenses/EPL-2.0.json",
+      "referenceNumber": 326,
       "name": "Eclipse Public License 2.0",
       "licenseId": "EPL-2.0",
       "seeAlso": [
         "https://www.eclipse.org/legal/epl-2.0",
-        "https://www.opensource.org/licenses/EPL-2.0"
+        "https://www.opensource.org/licenses/EPL-2.0",
+        "https://www.eclipse.org/legal/epl-v20.html",
+        "https://projects.eclipse.org/license/epl-2.0"
       ],
-      "isOsiApproved": true
+      "isOsiApproved": true,
+      "isFsfLibre": true
     },
     {
-      "reference": "./EUDatagrid.html",
+      "reference": "https://spdx.org/licenses/ErlPL-1.1.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/EUDatagrid.json",
-      "referenceNumber": "245",
+      "detailsUrl": "https://spdx.org/licenses/ErlPL-1.1.json",
+      "referenceNumber": 541,
+      "name": "Erlang Public License v1.1",
+      "licenseId": "ErlPL-1.1",
+      "seeAlso": [
+        "http://www.erlang.org/EPLICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/etalab-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/etalab-2.0.json",
+      "referenceNumber": 363,
+      "name": "Etalab Open License 2.0",
+      "licenseId": "etalab-2.0",
+      "seeAlso": [
+        "https://github.com/DISIC/politique-de-contribution-open-source/blob/master/LICENSE.pdf",
+        "https://raw.githubusercontent.com/DISIC/politique-de-contribution-open-source/master/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/EUDatagrid.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/EUDatagrid.json",
+      "referenceNumber": 262,
       "name": "EU DataGrid Software License",
       "licenseId": "EUDatagrid",
       "seeAlso": [
         "http://eu-datagrid.web.cern.ch/eu-datagrid/license.html",
         "https://opensource.org/licenses/EUDatagrid"
       ],
-      "isOsiApproved": true
+      "isOsiApproved": true,
+      "isFsfLibre": true
     },
     {
-      "reference": "./EUPL-1.0.html",
+      "reference": "https://spdx.org/licenses/EUPL-1.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/EUPL-1.0.json",
-      "referenceNumber": "88",
+      "detailsUrl": "https://spdx.org/licenses/EUPL-1.0.json",
+      "referenceNumber": 405,
       "name": "European Union Public License 1.0",
       "licenseId": "EUPL-1.0",
       "seeAlso": [
@@ -1638,11 +3057,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./EUPL-1.1.html",
+      "reference": "https://spdx.org/licenses/EUPL-1.1.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/EUPL-1.1.json",
-      "referenceNumber": "384",
+      "detailsUrl": "https://spdx.org/licenses/EUPL-1.1.json",
+      "referenceNumber": 393,
       "name": "European Union Public License 1.1",
       "licenseId": "EUPL-1.1",
       "seeAlso": [
@@ -1650,54 +3068,32 @@
         "https://joinup.ec.europa.eu/sites/default/files/custom-page/attachment/eupl1.1.-licence-en_0.pdf",
         "https://opensource.org/licenses/EUPL-1.1"
       ],
-      "isOsiApproved": true
+      "isOsiApproved": true,
+      "isFsfLibre": true
     },
     {
-      "reference": "./EUPL-1.2.html",
+      "reference": "https://spdx.org/licenses/EUPL-1.2.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/EUPL-1.2.json",
-      "referenceNumber": "251",
+      "detailsUrl": "https://spdx.org/licenses/EUPL-1.2.json",
+      "referenceNumber": 596,
       "name": "European Union Public License 1.2",
       "licenseId": "EUPL-1.2",
       "seeAlso": [
         "https://joinup.ec.europa.eu/page/eupl-text-11-12",
         "https://joinup.ec.europa.eu/sites/default/files/custom-page/attachment/eupl_v1.2_en.pdf",
+        "https://joinup.ec.europa.eu/sites/default/files/custom-page/attachment/2020-03/EUPL-1.2%20EN.txt",
         "https://joinup.ec.europa.eu/sites/default/files/inline-files/EUPL%20v1_2%20EN(1).txt",
         "http://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri\u003dCELEX:32017D0863",
-        "https://opensource.org/licenses/EUPL-1.1"
+        "https://opensource.org/licenses/EUPL-1.2"
       ],
-      "isOsiApproved": true
+      "isOsiApproved": true,
+      "isFsfLibre": true
     },
     {
-      "reference": "./Entessa.html",
+      "reference": "https://spdx.org/licenses/Eurosym.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Entessa.json",
-      "referenceNumber": "362",
-      "name": "Entessa Public License v1.0",
-      "licenseId": "Entessa",
-      "seeAlso": [
-        "https://opensource.org/licenses/Entessa"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./ErlPL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/ErlPL-1.1.json",
-      "referenceNumber": "383",
-      "name": "Erlang Public License v1.1",
-      "licenseId": "ErlPL-1.1",
-      "seeAlso": [
-        "http://www.erlang.org/EPLICENSE"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Eurosym.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Eurosym.json",
-      "referenceNumber": "159",
+      "detailsUrl": "https://spdx.org/licenses/Eurosym.json",
+      "referenceNumber": 299,
       "name": "Eurosym License",
       "licenseId": "Eurosym",
       "seeAlso": [
@@ -1706,74 +3102,60 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./FSFAP.html",
+      "reference": "https://spdx.org/licenses/Fair.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/FSFAP.json",
-      "referenceNumber": "370",
-      "name": "FSF All Permissive License",
-      "licenseId": "FSFAP",
-      "seeAlso": [
-        "https://www.gnu.org/prep/maintain/html_node/License-Notices-for-Other-Files.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./FSFUL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/FSFUL.json",
-      "referenceNumber": "2",
-      "name": "FSF Unlimited License",
-      "licenseId": "FSFUL",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/FSF_Unlimited_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./FSFULLR.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/FSFULLR.json",
-      "referenceNumber": "287",
-      "name": "FSF Unlimited License (with License Retention)",
-      "licenseId": "FSFULLR",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/FSF_Unlimited_License#License_Retention_Variant"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./FTL.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/FTL.json",
-      "referenceNumber": "351",
-      "name": "Freetype Project License",
-      "licenseId": "FTL",
-      "seeAlso": [
-        "http://freetype.fis.uniroma2.it/FTL.TXT",
-        "http://git.savannah.gnu.org/cgit/freetype/freetype2.git/tree/docs/FTL.TXT"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Fair.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Fair.json",
-      "referenceNumber": "244",
+      "detailsUrl": "https://spdx.org/licenses/Fair.json",
+      "referenceNumber": 190,
       "name": "Fair License",
       "licenseId": "Fair",
       "seeAlso": [
-        "http://fairlicense.org/",
+        "https://web.archive.org/web/20150926120323/http://fairlicense.org/",
         "https://opensource.org/licenses/Fair"
       ],
       "isOsiApproved": true
     },
     {
-      "reference": "./Frameworx-1.0.html",
+      "reference": "https://spdx.org/licenses/FBM.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Frameworx-1.0.json",
-      "referenceNumber": "350",
+      "detailsUrl": "https://spdx.org/licenses/FBM.json",
+      "referenceNumber": 476,
+      "name": "Fuzzy Bitmap License",
+      "licenseId": "FBM",
+      "seeAlso": [
+        "https://github.com/SWI-Prolog/packages-xpce/blob/161a40cd82004f731ba48024f9d30af388a7edf5/src/img/gifwrite.c#L21-L26"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/FDK-AAC.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/FDK-AAC.json",
+      "referenceNumber": 44,
+      "name": "Fraunhofer FDK AAC Codec Library",
+      "licenseId": "FDK-AAC",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/FDK-AAC",
+        "https://directory.fsf.org/wiki/License:Fdk"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Ferguson-Twofish.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Ferguson-Twofish.json",
+      "referenceNumber": 662,
+      "name": "Ferguson Twofish License",
+      "licenseId": "Ferguson-Twofish",
+      "seeAlso": [
+        "https://github.com/wernerd/ZRTPCPP/blob/6b3cd8e6783642292bad0c21e3e5e5ce45ff3e03/cryptcommon/twofish.c#L113C3-L127"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Frameworx-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Frameworx-1.0.json",
+      "referenceNumber": 376,
       "name": "Frameworx Open License 1.0",
       "licenseId": "Frameworx-1.0",
       "seeAlso": [
@@ -1782,10 +3164,22 @@
       "isOsiApproved": true
     },
     {
-      "reference": "./FreeImage.html",
+      "reference": "https://spdx.org/licenses/FreeBSD-DOC.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/FreeImage.json",
-      "referenceNumber": "347",
+      "detailsUrl": "https://spdx.org/licenses/FreeBSD-DOC.json",
+      "referenceNumber": 645,
+      "name": "FreeBSD Documentation License",
+      "licenseId": "FreeBSD-DOC",
+      "seeAlso": [
+        "https://www.freebsd.org/copyright/freebsd-doc-license/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/FreeImage.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/FreeImage.json",
+      "referenceNumber": 264,
       "name": "FreeImage Public License v1.0",
       "licenseId": "FreeImage",
       "seeAlso": [
@@ -1794,383 +3188,455 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./GFDL-1.1.html",
+      "reference": "https://spdx.org/licenses/FSFAP.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/FSFAP.json",
+      "referenceNumber": 561,
+      "name": "FSF All Permissive License",
+      "licenseId": "FSFAP",
+      "seeAlso": [
+        "https://www.gnu.org/prep/maintain/html_node/License-Notices-for-Other-Files.html"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/FSFAP-no-warranty-disclaimer.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/FSFAP-no-warranty-disclaimer.json",
+      "referenceNumber": 629,
+      "name": "FSF All Permissive License (without Warranty)",
+      "licenseId": "FSFAP-no-warranty-disclaimer",
+      "seeAlso": [
+        "https://git.savannah.gnu.org/cgit/wget.git/tree/util/trunc.c?h\u003dv1.21.3\u0026id\u003d40747a11e44ced5a8ac628a41f879ced3e2ebce9#n6"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/FSFUL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/FSFUL.json",
+      "referenceNumber": 59,
+      "name": "FSF Unlimited License",
+      "licenseId": "FSFUL",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/FSF_Unlimited_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/FSFULLR.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/FSFULLR.json",
+      "referenceNumber": 322,
+      "name": "FSF Unlimited License (with License Retention)",
+      "licenseId": "FSFULLR",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/FSF_Unlimited_License#License_Retention_Variant"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/FSFULLRSD.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/FSFULLRSD.json",
+      "referenceNumber": 300,
+      "name": "FSF Unlimited License (with License Retention and Short Disclaimer)",
+      "licenseId": "FSFULLRSD",
+      "seeAlso": [
+        "https://git.savannah.gnu.org/cgit/gnulib.git/tree/modules/COPYING?id\u003d7b08932179d0d6b017f7df01a2ddf6e096b038e3"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/FSFULLRWD.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/FSFULLRWD.json",
+      "referenceNumber": 245,
+      "name": "FSF Unlimited License (With License Retention and Warranty Disclaimer)",
+      "licenseId": "FSFULLRWD",
+      "seeAlso": [
+        "https://lists.gnu.org/archive/html/autoconf/2012-04/msg00061.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/FSL-1.1-ALv2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/FSL-1.1-ALv2.json",
+      "referenceNumber": 585,
+      "name": "Functional Source License, Version 1.1, ALv2 Future License",
+      "licenseId": "FSL-1.1-ALv2",
+      "seeAlso": [
+        "https://fsl.software/FSL-1.1-ALv2.template.md"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/FSL-1.1-MIT.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/FSL-1.1-MIT.json",
+      "referenceNumber": 639,
+      "name": "Functional Source License, Version 1.1, MIT Future License",
+      "licenseId": "FSL-1.1-MIT",
+      "seeAlso": [
+        "https://fsl.software/FSL-1.1-MIT.template.md"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/FTL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/FTL.json",
+      "referenceNumber": 417,
+      "name": "Freetype Project License",
+      "licenseId": "FTL",
+      "seeAlso": [
+        "http://freetype.fis.uniroma2.it/FTL.TXT",
+        "http://git.savannah.gnu.org/cgit/freetype/freetype2.git/tree/docs/FTL.TXT",
+        "http://gitlab.freedesktop.org/freetype/freetype/-/raw/master/docs/FTL.TXT"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Furuseth.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Furuseth.json",
+      "referenceNumber": 72,
+      "name": "Furuseth License",
+      "licenseId": "Furuseth",
+      "seeAlso": [
+        "https://git.openldap.org/openldap/openldap/-/blob/master/COPYRIGHT?ref_type\u003dheads#L39-51"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/fwlw.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/fwlw.json",
+      "referenceNumber": 529,
+      "name": "fwlw License",
+      "licenseId": "fwlw",
+      "seeAlso": [
+        "https://mirrors.nic.cz/tex-archive/macros/latex/contrib/fwlw/README"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Game-Programming-Gems.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Game-Programming-Gems.json",
+      "referenceNumber": 246,
+      "name": "Game Programming Gems License",
+      "licenseId": "Game-Programming-Gems",
+      "seeAlso": [
+        "https://github.com/OGRECave/ogre/blob/master/OgreMain/include/OgreSingleton.h#L28C3-L35C46"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GCR-docs.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GCR-docs.json",
+      "referenceNumber": 270,
+      "name": "Gnome GCR Documentation License",
+      "licenseId": "GCR-docs",
+      "seeAlso": [
+        "https://github.com/GNOME/gcr/blob/master/docs/COPYING"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GD.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GD.json",
+      "referenceNumber": 549,
+      "name": "GD License",
+      "licenseId": "GD",
+      "seeAlso": [
+        "https://libgd.github.io/manuals/2.3.0/files/license-txt.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/generic-xts.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/generic-xts.json",
+      "referenceNumber": 132,
+      "name": "Generic XTS License",
+      "licenseId": "generic-xts",
+      "seeAlso": [
+        "https://github.com/mhogomchungu/zuluCrypt/blob/master/external_libraries/tcplay/generic_xts.c"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.1.html",
       "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GFDL-1.1.json",
-      "referenceNumber": "239",
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.1.json",
+      "referenceNumber": 533,
       "name": "GNU Free Documentation License v1.1",
       "licenseId": "GFDL-1.1",
       "seeAlso": [
         "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
       ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.1-invariants-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-invariants-only.json",
+      "referenceNumber": 271,
+      "name": "GNU Free Documentation License v1.1 only - invariants",
+      "licenseId": "GFDL-1.1-invariants-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+      ],
       "isOsiApproved": false
     },
     {
-      "reference": "./GFDL-1.1-only.html",
+      "reference": "https://spdx.org/licenses/GFDL-1.1-invariants-or-later.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GFDL-1.1-only.json",
-      "referenceNumber": "94",
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-invariants-or-later.json",
+      "referenceNumber": 538,
+      "name": "GNU Free Documentation License v1.1 or later - invariants",
+      "licenseId": "GFDL-1.1-invariants-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.1-no-invariants-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-no-invariants-only.json",
+      "referenceNumber": 609,
+      "name": "GNU Free Documentation License v1.1 only - no invariants",
+      "licenseId": "GFDL-1.1-no-invariants-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.1-no-invariants-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-no-invariants-or-later.json",
+      "referenceNumber": 689,
+      "name": "GNU Free Documentation License v1.1 or later - no invariants",
+      "licenseId": "GFDL-1.1-no-invariants-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.1-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-only.json",
+      "referenceNumber": 456,
       "name": "GNU Free Documentation License v1.1 only",
       "licenseId": "GFDL-1.1-only",
       "seeAlso": [
         "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": false,
+      "isFsfLibre": true
     },
     {
-      "reference": "./GFDL-1.1-or-later.html",
+      "reference": "https://spdx.org/licenses/GFDL-1.1-or-later.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GFDL-1.1-or-later.json",
-      "referenceNumber": "113",
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-or-later.json",
+      "referenceNumber": 67,
       "name": "GNU Free Documentation License v1.1 or later",
       "licenseId": "GFDL-1.1-or-later",
       "seeAlso": [
         "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": false,
+      "isFsfLibre": true
     },
     {
-      "reference": "./GFDL-1.2.html",
+      "reference": "https://spdx.org/licenses/GFDL-1.2.html",
       "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GFDL-1.2.json",
-      "referenceNumber": "183",
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.2.json",
+      "referenceNumber": 350,
       "name": "GNU Free Documentation License v1.2",
       "licenseId": "GFDL-1.2",
       "seeAlso": [
         "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
       ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.2-invariants-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-invariants-only.json",
+      "referenceNumber": 192,
+      "name": "GNU Free Documentation License v1.2 only - invariants",
+      "licenseId": "GFDL-1.2-invariants-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+      ],
       "isOsiApproved": false
     },
     {
-      "reference": "./GFDL-1.2-only.html",
+      "reference": "https://spdx.org/licenses/GFDL-1.2-invariants-or-later.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GFDL-1.2-only.json",
-      "referenceNumber": "81",
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-invariants-or-later.json",
+      "referenceNumber": 261,
+      "name": "GNU Free Documentation License v1.2 or later - invariants",
+      "licenseId": "GFDL-1.2-invariants-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.2-no-invariants-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-no-invariants-only.json",
+      "referenceNumber": 101,
+      "name": "GNU Free Documentation License v1.2 only - no invariants",
+      "licenseId": "GFDL-1.2-no-invariants-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.2-no-invariants-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-no-invariants-or-later.json",
+      "referenceNumber": 244,
+      "name": "GNU Free Documentation License v1.2 or later - no invariants",
+      "licenseId": "GFDL-1.2-no-invariants-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.2-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-only.json",
+      "referenceNumber": 595,
       "name": "GNU Free Documentation License v1.2 only",
       "licenseId": "GFDL-1.2-only",
       "seeAlso": [
         "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": false,
+      "isFsfLibre": true
     },
     {
-      "reference": "./GFDL-1.2-or-later.html",
+      "reference": "https://spdx.org/licenses/GFDL-1.2-or-later.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GFDL-1.2-or-later.json",
-      "referenceNumber": "121",
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-or-later.json",
+      "referenceNumber": 488,
       "name": "GNU Free Documentation License v1.2 or later",
       "licenseId": "GFDL-1.2-or-later",
       "seeAlso": [
         "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": false,
+      "isFsfLibre": true
     },
     {
-      "reference": "./GFDL-1.3.html",
+      "reference": "https://spdx.org/licenses/GFDL-1.3.html",
       "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GFDL-1.3.json",
-      "referenceNumber": "342",
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.3.json",
+      "referenceNumber": 652,
       "name": "GNU Free Documentation License v1.3",
       "licenseId": "GFDL-1.3",
       "seeAlso": [
         "https://www.gnu.org/licenses/fdl-1.3.txt"
       ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.3-invariants-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-invariants-only.json",
+      "referenceNumber": 69,
+      "name": "GNU Free Documentation License v1.3 only - invariants",
+      "licenseId": "GFDL-1.3-invariants-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/fdl-1.3.txt"
+      ],
       "isOsiApproved": false
     },
     {
-      "reference": "./GFDL-1.3-only.html",
+      "reference": "https://spdx.org/licenses/GFDL-1.3-invariants-or-later.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GFDL-1.3-only.json",
-      "referenceNumber": "186",
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-invariants-or-later.json",
+      "referenceNumber": 550,
+      "name": "GNU Free Documentation License v1.3 or later - invariants",
+      "licenseId": "GFDL-1.3-invariants-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/fdl-1.3.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.3-no-invariants-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-no-invariants-only.json",
+      "referenceNumber": 516,
+      "name": "GNU Free Documentation License v1.3 only - no invariants",
+      "licenseId": "GFDL-1.3-no-invariants-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/fdl-1.3.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.3-no-invariants-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-no-invariants-or-later.json",
+      "referenceNumber": 73,
+      "name": "GNU Free Documentation License v1.3 or later - no invariants",
+      "licenseId": "GFDL-1.3-no-invariants-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/fdl-1.3.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GFDL-1.3-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-only.json",
+      "referenceNumber": 223,
       "name": "GNU Free Documentation License v1.3 only",
       "licenseId": "GFDL-1.3-only",
       "seeAlso": [
         "https://www.gnu.org/licenses/fdl-1.3.txt"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": false,
+      "isFsfLibre": true
     },
     {
-      "reference": "./GFDL-1.3-or-later.html",
+      "reference": "https://spdx.org/licenses/GFDL-1.3-or-later.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GFDL-1.3-or-later.json",
-      "referenceNumber": "48",
+      "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-or-later.json",
+      "referenceNumber": 633,
       "name": "GNU Free Documentation License v1.3 or later",
       "licenseId": "GFDL-1.3-or-later",
       "seeAlso": [
         "https://www.gnu.org/licenses/fdl-1.3.txt"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": false,
+      "isFsfLibre": true
     },
     {
-      "reference": "./GL2PS.html",
+      "reference": "https://spdx.org/licenses/Giftware.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/GL2PS.json",
-      "referenceNumber": "292",
-      "name": "GL2PS License",
-      "licenseId": "GL2PS",
-      "seeAlso": [
-        "http://www.geuz.org/gl2ps/COPYING.GL2PS"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GPL-1.0.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-1.0.json",
-      "referenceNumber": "308",
-      "name": "GNU General Public License v1.0 only",
-      "licenseId": "GPL-1.0",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GPL-1.0+.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-1.0+.json",
-      "referenceNumber": "191",
-      "name": "GNU General Public License v1.0 or later",
-      "licenseId": "GPL-1.0+",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GPL-1.0-only.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/GPL-1.0-only.json",
-      "referenceNumber": "15",
-      "name": "GNU General Public License v1.0 only",
-      "licenseId": "GPL-1.0-only",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GPL-1.0-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/GPL-1.0-or-later.json",
-      "referenceNumber": "123",
-      "name": "GNU General Public License v1.0 or later",
-      "licenseId": "GPL-1.0-or-later",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GPL-2.0.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-2.0.json",
-      "referenceNumber": "334",
-      "name": "GNU General Public License v2.0 only",
-      "licenseId": "GPL-2.0",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
-        "https://opensource.org/licenses/GPL-2.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./GPL-2.0+.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-2.0+.json",
-      "referenceNumber": "377",
-      "name": "GNU General Public License v2.0 or later",
-      "licenseId": "GPL-2.0+",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
-        "https://opensource.org/licenses/GPL-2.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./GPL-2.0-only.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-2.0-only.json",
-      "referenceNumber": "219",
-      "name": "GNU General Public License v2.0 only",
-      "licenseId": "GPL-2.0-only",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
-        "https://opensource.org/licenses/GPL-2.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./GPL-2.0-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-2.0-or-later.json",
-      "referenceNumber": "240",
-      "name": "GNU General Public License v2.0 or later",
-      "licenseId": "GPL-2.0-or-later",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
-        "https://opensource.org/licenses/GPL-2.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./GPL-2.0-with-GCC-exception.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-GCC-exception.json",
-      "referenceNumber": "318",
-      "name": "GNU General Public License v2.0 w/GCC Runtime Library exception",
-      "licenseId": "GPL-2.0-with-GCC-exception",
-      "seeAlso": [
-        "https://gcc.gnu.org/git/?p\u003dgcc.git;a\u003dblob;f\u003dgcc/libgcc1.c;h\u003d762f5143fc6eed57b6797c82710f3538aa52b40b;hb\u003dcb143a3ce4fb417c68f5fa2691a1b1b1053dfba9#l10"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GPL-2.0-with-autoconf-exception.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-autoconf-exception.json",
-      "referenceNumber": "34",
-      "name": "GNU General Public License v2.0 w/Autoconf exception",
-      "licenseId": "GPL-2.0-with-autoconf-exception",
-      "seeAlso": [
-        "http://ac-archive.sourceforge.net/doc/copyright.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GPL-2.0-with-bison-exception.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-bison-exception.json",
-      "referenceNumber": "348",
-      "name": "GNU General Public License v2.0 w/Bison exception",
-      "licenseId": "GPL-2.0-with-bison-exception",
-      "seeAlso": [
-        "http://git.savannah.gnu.org/cgit/bison.git/tree/data/yacc.c?id\u003d193d7c7054ba7197b0789e14965b739162319b5e#n141"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GPL-2.0-with-classpath-exception.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-classpath-exception.json",
-      "referenceNumber": "211",
-      "name": "GNU General Public License v2.0 w/Classpath exception",
-      "licenseId": "GPL-2.0-with-classpath-exception",
-      "seeAlso": [
-        "https://www.gnu.org/software/classpath/license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GPL-2.0-with-font-exception.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-font-exception.json",
-      "referenceNumber": "22",
-      "name": "GNU General Public License v2.0 w/Font exception",
-      "licenseId": "GPL-2.0-with-font-exception",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/gpl-faq.html#FontException"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GPL-3.0.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-3.0.json",
-      "referenceNumber": "389",
-      "name": "GNU General Public License v3.0 only",
-      "licenseId": "GPL-3.0",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
-        "https://opensource.org/licenses/GPL-3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./GPL-3.0+.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-3.0+.json",
-      "referenceNumber": "141",
-      "name": "GNU General Public License v3.0 or later",
-      "licenseId": "GPL-3.0+",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
-        "https://opensource.org/licenses/GPL-3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./GPL-3.0-only.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-3.0-only.json",
-      "referenceNumber": "116",
-      "name": "GNU General Public License v3.0 only",
-      "licenseId": "GPL-3.0-only",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
-        "https://opensource.org/licenses/GPL-3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./GPL-3.0-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-3.0-or-later.json",
-      "referenceNumber": "375",
-      "name": "GNU General Public License v3.0 or later",
-      "licenseId": "GPL-3.0-or-later",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
-        "https://opensource.org/licenses/GPL-3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./GPL-3.0-with-GCC-exception.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-3.0-with-GCC-exception.json",
-      "referenceNumber": "6",
-      "name": "GNU General Public License v3.0 w/GCC Runtime Library exception",
-      "licenseId": "GPL-3.0-with-GCC-exception",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/gcc-exception-3.1.html"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./GPL-3.0-with-autoconf-exception.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-3.0-with-autoconf-exception.json",
-      "referenceNumber": "8",
-      "name": "GNU General Public License v3.0 w/Autoconf exception",
-      "licenseId": "GPL-3.0-with-autoconf-exception",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/autoconf-exception-3.0.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Giftware.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Giftware.json",
-      "referenceNumber": "355",
+      "detailsUrl": "https://spdx.org/licenses/Giftware.json",
+      "referenceNumber": 519,
       "name": "Giftware License",
       "licenseId": "Giftware",
       "seeAlso": [
@@ -2179,10 +3645,22 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./Glide.html",
+      "reference": "https://spdx.org/licenses/GL2PS.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Glide.json",
-      "referenceNumber": "111",
+      "detailsUrl": "https://spdx.org/licenses/GL2PS.json",
+      "referenceNumber": 360,
+      "name": "GL2PS License",
+      "licenseId": "GL2PS",
+      "seeAlso": [
+        "http://www.geuz.org/gl2ps/COPYING.GL2PS"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Glide.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Glide.json",
+      "referenceNumber": 71,
       "name": "3dfx Glide License",
       "licenseId": "Glide",
       "seeAlso": [
@@ -2191,10 +3669,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./Glulxe.html",
+      "reference": "https://spdx.org/licenses/Glulxe.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Glulxe.json",
-      "referenceNumber": "192",
+      "detailsUrl": "https://spdx.org/licenses/Glulxe.json",
+      "referenceNumber": 635,
       "name": "Glulxe License",
       "licenseId": "Glulxe",
       "seeAlso": [
@@ -2203,35 +3681,331 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./HPND.html",
+      "reference": "https://spdx.org/licenses/GLWTPL.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/HPND.json",
-      "referenceNumber": "142",
-      "name": "Historical Permission Notice and Disclaimer",
-      "licenseId": "HPND",
+      "detailsUrl": "https://spdx.org/licenses/GLWTPL.json",
+      "referenceNumber": 27,
+      "name": "Good Luck With That Public License",
+      "licenseId": "GLWTPL",
       "seeAlso": [
-        "https://opensource.org/licenses/HPND"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./HPND-sell-variant.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/HPND-sell-variant.json",
-      "referenceNumber": "152",
-      "name": "Historical Permission Notice and Disclaimer - sell variant",
-      "licenseId": "HPND-sell-variant",
-      "seeAlso": [
-        "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/net/sunrpc/auth_gss/gss_generic_token.c?h\u003dv4.19"
+        "https://github.com/me-shaon/GLWTPL/commit/da5f6bc734095efbacb442c0b31e33a65b9d6e85"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./HaskellReport.html",
+      "reference": "https://spdx.org/licenses/gnuplot.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/HaskellReport.json",
-      "referenceNumber": "197",
+      "detailsUrl": "https://spdx.org/licenses/gnuplot.json",
+      "referenceNumber": 247,
+      "name": "gnuplot License",
+      "licenseId": "gnuplot",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Gnuplot"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-1.0.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/GPL-1.0.json",
+      "referenceNumber": 10,
+      "name": "GNU General Public License v1.0 only",
+      "licenseId": "GPL-1.0",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-1.0+.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/GPL-1.0+.json",
+      "referenceNumber": 177,
+      "name": "GNU General Public License v1.0 or later",
+      "licenseId": "GPL-1.0+",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-1.0-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GPL-1.0-only.json",
+      "referenceNumber": 152,
+      "name": "GNU General Public License v1.0 only",
+      "licenseId": "GPL-1.0-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-1.0-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GPL-1.0-or-later.json",
+      "referenceNumber": 68,
+      "name": "GNU General Public License v1.0 or later",
+      "licenseId": "GPL-1.0-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-2.0.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/GPL-2.0.json",
+      "referenceNumber": 688,
+      "name": "GNU General Public License v2.0 only",
+      "licenseId": "GPL-2.0",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
+        "https://opensource.org/licenses/GPL-2.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-2.0+.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/GPL-2.0+.json",
+      "referenceNumber": 144,
+      "name": "GNU General Public License v2.0 or later",
+      "licenseId": "GPL-2.0+",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
+        "https://opensource.org/licenses/GPL-2.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-2.0-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GPL-2.0-only.json",
+      "referenceNumber": 461,
+      "name": "GNU General Public License v2.0 only",
+      "licenseId": "GPL-2.0-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
+        "https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt",
+        "https://opensource.org/licenses/GPL-2.0",
+        "https://github.com/openjdk/jdk/blob/6162e2c5213c5dd7c1127fd9616b543efa898962/LICENSE"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-2.0-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GPL-2.0-or-later.json",
+      "referenceNumber": 99,
+      "name": "GNU General Public License v2.0 or later",
+      "licenseId": "GPL-2.0-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
+        "https://opensource.org/licenses/GPL-2.0",
+        "https://github.com/openjdk/jdk/blob/6162e2c5213c5dd7c1127fd9616b543efa898962/LICENSE"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-2.0-with-autoconf-exception.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-autoconf-exception.json",
+      "referenceNumber": 618,
+      "name": "GNU General Public License v2.0 w/Autoconf exception",
+      "licenseId": "GPL-2.0-with-autoconf-exception",
+      "seeAlso": [
+        "http://ac-archive.sourceforge.net/doc/copyright.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-2.0-with-bison-exception.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-bison-exception.json",
+      "referenceNumber": 358,
+      "name": "GNU General Public License v2.0 w/Bison exception",
+      "licenseId": "GPL-2.0-with-bison-exception",
+      "seeAlso": [
+        "http://git.savannah.gnu.org/cgit/bison.git/tree/data/yacc.c?id\u003d193d7c7054ba7197b0789e14965b739162319b5e#n141"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-2.0-with-classpath-exception.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-classpath-exception.json",
+      "referenceNumber": 171,
+      "name": "GNU General Public License v2.0 w/Classpath exception",
+      "licenseId": "GPL-2.0-with-classpath-exception",
+      "seeAlso": [
+        "https://www.gnu.org/software/classpath/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-2.0-with-font-exception.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-font-exception.json",
+      "referenceNumber": 151,
+      "name": "GNU General Public License v2.0 w/Font exception",
+      "licenseId": "GPL-2.0-with-font-exception",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/gpl-faq.html#FontException"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-2.0-with-GCC-exception.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-GCC-exception.json",
+      "referenceNumber": 525,
+      "name": "GNU General Public License v2.0 w/GCC Runtime Library exception",
+      "licenseId": "GPL-2.0-with-GCC-exception",
+      "seeAlso": [
+        "https://gcc.gnu.org/git/?p\u003dgcc.git;a\u003dblob;f\u003dgcc/libgcc1.c;h\u003d762f5143fc6eed57b6797c82710f3538aa52b40b;hb\u003dcb143a3ce4fb417c68f5fa2691a1b1b1053dfba9#l10"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-3.0.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/GPL-3.0.json",
+      "referenceNumber": 503,
+      "name": "GNU General Public License v3.0 only",
+      "licenseId": "GPL-3.0",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
+        "https://opensource.org/licenses/GPL-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-3.0+.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/GPL-3.0+.json",
+      "referenceNumber": 131,
+      "name": "GNU General Public License v3.0 or later",
+      "licenseId": "GPL-3.0+",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
+        "https://opensource.org/licenses/GPL-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-3.0-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GPL-3.0-only.json",
+      "referenceNumber": 632,
+      "name": "GNU General Public License v3.0 only",
+      "licenseId": "GPL-3.0-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
+        "https://opensource.org/licenses/GPL-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-3.0-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/GPL-3.0-or-later.json",
+      "referenceNumber": 467,
+      "name": "GNU General Public License v3.0 or later",
+      "licenseId": "GPL-3.0-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
+        "https://opensource.org/licenses/GPL-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-3.0-with-autoconf-exception.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/GPL-3.0-with-autoconf-exception.json",
+      "referenceNumber": 650,
+      "name": "GNU General Public License v3.0 w/Autoconf exception",
+      "licenseId": "GPL-3.0-with-autoconf-exception",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/autoconf-exception-3.0.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/GPL-3.0-with-GCC-exception.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/GPL-3.0-with-GCC-exception.json",
+      "referenceNumber": 601,
+      "name": "GNU General Public License v3.0 w/GCC Runtime Library exception",
+      "licenseId": "GPL-3.0-with-GCC-exception",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/gcc-exception-3.1.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Graphics-Gems.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Graphics-Gems.json",
+      "referenceNumber": 255,
+      "name": "Graphics Gems License",
+      "licenseId": "Graphics-Gems",
+      "seeAlso": [
+        "https://github.com/erich666/GraphicsGems/blob/master/LICENSE.md"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/gSOAP-1.3b.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/gSOAP-1.3b.json",
+      "referenceNumber": 668,
+      "name": "gSOAP Public License v1.3b",
+      "licenseId": "gSOAP-1.3b",
+      "seeAlso": [
+        "http://www.cs.fsu.edu/~engelen/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/gtkbook.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/gtkbook.json",
+      "referenceNumber": 465,
+      "name": "gtkbook License",
+      "licenseId": "gtkbook",
+      "seeAlso": [
+        "https://github.com/slogan621/gtkbook",
+        "https://github.com/oetiker/rrdtool-1.x/blob/master/src/plbasename.c#L8-L11"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Gutmann.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Gutmann.json",
+      "referenceNumber": 524,
+      "name": "Gutmann License",
+      "licenseId": "Gutmann",
+      "seeAlso": [
+        "https://www.cs.auckland.ac.nz/~pgut001/dumpasn1.c"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HaskellReport.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HaskellReport.json",
+      "referenceNumber": 605,
       "name": "Haskell Language Report License",
       "licenseId": "HaskellReport",
       "seeAlso": [
@@ -2240,10 +4014,391 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./IBM-pibs.html",
+      "reference": "https://spdx.org/licenses/HDF5.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/IBM-pibs.json",
-      "referenceNumber": "225",
+      "detailsUrl": "https://spdx.org/licenses/HDF5.json",
+      "referenceNumber": 19,
+      "name": "HDF5 License",
+      "licenseId": "HDF5",
+      "seeAlso": [
+        "https://github.com/HDFGroup/hdf5/?tab\u003dLicense-1-ov-file#readme"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/hdparm.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/hdparm.json",
+      "referenceNumber": 283,
+      "name": "hdparm License",
+      "licenseId": "hdparm",
+      "seeAlso": [
+        "https://github.com/Distrotech/hdparm/blob/4517550db29a91420fb2b020349523b1b4512df2/LICENSE.TXT"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HIDAPI.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HIDAPI.json",
+      "referenceNumber": 310,
+      "name": "HIDAPI License",
+      "licenseId": "HIDAPI",
+      "seeAlso": [
+        "https://github.com/signal11/hidapi/blob/master/LICENSE-orig.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Hippocratic-2.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Hippocratic-2.1.json",
+      "referenceNumber": 87,
+      "name": "Hippocratic License 2.1",
+      "licenseId": "Hippocratic-2.1",
+      "seeAlso": [
+        "https://firstdonoharm.dev/version/2/1/license.html",
+        "https://github.com/EthicalSource/hippocratic-license/blob/58c0e646d64ff6fbee275bfe2b9492f914e3ab2a/LICENSE.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HP-1986.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HP-1986.json",
+      "referenceNumber": 282,
+      "name": "Hewlett-Packard 1986 License",
+      "licenseId": "HP-1986",
+      "seeAlso": [
+        "https://sourceware.org/git/?p\u003dnewlib-cygwin.git;a\u003dblob;f\u003dnewlib/libc/machine/hppa/memchr.S;h\u003d1cca3e5e8867aa4bffef1f75a5c1bba25c0c441e;hb\u003dHEAD#l2"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HP-1989.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HP-1989.json",
+      "referenceNumber": 8,
+      "name": "Hewlett-Packard 1989 License",
+      "licenseId": "HP-1989",
+      "seeAlso": [
+        "https://github.com/bleargh45/Data-UUID/blob/master/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND.json",
+      "referenceNumber": 209,
+      "name": "Historical Permission Notice and Disclaimer",
+      "licenseId": "HPND",
+      "seeAlso": [
+        "https://opensource.org/licenses/HPND",
+        "http://lists.opensource.org/pipermail/license-discuss_lists.opensource.org/2002-November/006304.html"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-DEC.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-DEC.json",
+      "referenceNumber": 112,
+      "name": "Historical Permission Notice and Disclaimer - DEC variant",
+      "licenseId": "HPND-DEC",
+      "seeAlso": [
+        "https://gitlab.freedesktop.org/xorg/app/xkbcomp/-/blob/master/COPYING?ref_type\u003dheads#L69"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-doc.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-doc.json",
+      "referenceNumber": 600,
+      "name": "Historical Permission Notice and Disclaimer - documentation variant",
+      "licenseId": "HPND-doc",
+      "seeAlso": [
+        "https://gitlab.freedesktop.org/xorg/lib/libxext/-/blob/master/COPYING?ref_type\u003dheads#L185-197",
+        "https://gitlab.freedesktop.org/xorg/lib/libxtst/-/blob/master/COPYING?ref_type\u003dheads#L70-77"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-doc-sell.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-doc-sell.json",
+      "referenceNumber": 306,
+      "name": "Historical Permission Notice and Disclaimer - documentation sell variant",
+      "licenseId": "HPND-doc-sell",
+      "seeAlso": [
+        "https://gitlab.freedesktop.org/xorg/lib/libxtst/-/blob/master/COPYING?ref_type\u003dheads#L108-117",
+        "https://gitlab.freedesktop.org/xorg/lib/libxext/-/blob/master/COPYING?ref_type\u003dheads#L153-162"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-export-US.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-export-US.json",
+      "referenceNumber": 459,
+      "name": "HPND with US Government export control warning",
+      "licenseId": "HPND-export-US",
+      "seeAlso": [
+        "https://www.kermitproject.org/ck90.html#source"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-export-US-acknowledgement.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-export-US-acknowledgement.json",
+      "referenceNumber": 487,
+      "name": "HPND with US Government export control warning and acknowledgment",
+      "licenseId": "HPND-export-US-acknowledgement",
+      "seeAlso": [
+        "https://github.com/krb5/krb5/blob/krb5-1.21.2-final/NOTICE#L831-L852",
+        "https://web.mit.edu/kerberos/krb5-1.21/doc/mitK5license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-export-US-modify.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-export-US-modify.json",
+      "referenceNumber": 172,
+      "name": "HPND with US Government export control warning and modification rqmt",
+      "licenseId": "HPND-export-US-modify",
+      "seeAlso": [
+        "https://github.com/krb5/krb5/blob/krb5-1.21.2-final/NOTICE#L1157-L1182",
+        "https://github.com/pythongssapi/k5test/blob/v0.10.3/K5TEST-LICENSE.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-export2-US.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-export2-US.json",
+      "referenceNumber": 1,
+      "name": "HPND with US Government export control and 2 disclaimers",
+      "licenseId": "HPND-export2-US",
+      "seeAlso": [
+        "https://github.com/krb5/krb5/blob/krb5-1.21.2-final/NOTICE#L111-L133",
+        "https://web.mit.edu/kerberos/krb5-1.21/doc/mitK5license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-Fenneberg-Livingston.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-Fenneberg-Livingston.json",
+      "referenceNumber": 445,
+      "name": "Historical Permission Notice and Disclaimer - Fenneberg-Livingston variant",
+      "licenseId": "HPND-Fenneberg-Livingston",
+      "seeAlso": [
+        "https://github.com/FreeRADIUS/freeradius-client/blob/master/COPYRIGHT#L32",
+        "https://github.com/radcli/radcli/blob/master/COPYRIGHT#L34"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-INRIA-IMAG.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-INRIA-IMAG.json",
+      "referenceNumber": 233,
+      "name": "Historical Permission Notice and Disclaimer    - INRIA-IMAG variant",
+      "licenseId": "HPND-INRIA-IMAG",
+      "seeAlso": [
+        "https://github.com/ppp-project/ppp/blob/master/pppd/ipv6cp.c#L75-L83"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-Intel.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-Intel.json",
+      "referenceNumber": 228,
+      "name": "Historical Permission Notice and Disclaimer - Intel variant",
+      "licenseId": "HPND-Intel",
+      "seeAlso": [
+        "https://sourceware.org/git/?p\u003dnewlib-cygwin.git;a\u003dblob;f\u003dnewlib/libc/machine/i960/memcpy.S;hb\u003dHEAD"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-Kevlin-Henney.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-Kevlin-Henney.json",
+      "referenceNumber": 528,
+      "name": "Historical Permission Notice and Disclaimer - Kevlin Henney variant",
+      "licenseId": "HPND-Kevlin-Henney",
+      "seeAlso": [
+        "https://github.com/mruby/mruby/blob/83d12f8d52522cdb7c8cc46fad34821359f453e6/mrbgems/mruby-dir/src/Win/dirent.c#L127-L140"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-Markus-Kuhn.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-Markus-Kuhn.json",
+      "referenceNumber": 623,
+      "name": "Historical Permission Notice and Disclaimer - Markus Kuhn variant",
+      "licenseId": "HPND-Markus-Kuhn",
+      "seeAlso": [
+        "https://www.cl.cam.ac.uk/~mgk25/ucs/wcwidth.c",
+        "https://sourceware.org/git/?p\u003dbinutils-gdb.git;a\u003dblob;f\u003dreadline/readline/support/wcwidth.c;h\u003d0f5ec995796f4813abbcf4972aec0378ab74722a;hb\u003dHEAD#l55"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-merchantability-variant.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-merchantability-variant.json",
+      "referenceNumber": 157,
+      "name": "Historical Permission Notice and Disclaimer - merchantability variant",
+      "licenseId": "HPND-merchantability-variant",
+      "seeAlso": [
+        "https://sourceware.org/git/?p\u003dnewlib-cygwin.git;a\u003dblob;f\u003dnewlib/libc/misc/fini.c;hb\u003dHEAD"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-MIT-disclaimer.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-MIT-disclaimer.json",
+      "referenceNumber": 313,
+      "name": "Historical Permission Notice and Disclaimer with MIT disclaimer",
+      "licenseId": "HPND-MIT-disclaimer",
+      "seeAlso": [
+        "https://metacpan.org/release/NLNETLABS/Net-DNS-SEC-1.22/source/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-Netrek.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-Netrek.json",
+      "referenceNumber": 387,
+      "name": "Historical Permission Notice and Disclaimer - Netrek variant",
+      "licenseId": "HPND-Netrek",
+      "seeAlso": [],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-Pbmplus.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-Pbmplus.json",
+      "referenceNumber": 339,
+      "name": "Historical Permission Notice and Disclaimer - Pbmplus variant",
+      "licenseId": "HPND-Pbmplus",
+      "seeAlso": [
+        "https://sourceforge.net/p/netpbm/code/HEAD/tree/super_stable/netpbm.c#l8"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-sell-MIT-disclaimer-xserver.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-sell-MIT-disclaimer-xserver.json",
+      "referenceNumber": 341,
+      "name": "Historical Permission Notice and Disclaimer - sell xserver variant with MIT disclaimer",
+      "licenseId": "HPND-sell-MIT-disclaimer-xserver",
+      "seeAlso": [
+        "https://gitlab.freedesktop.org/xorg/xserver/-/blob/master/COPYING?ref_type\u003dheads#L1781"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-sell-regexpr.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-sell-regexpr.json",
+      "referenceNumber": 681,
+      "name": "Historical Permission Notice and Disclaimer - sell regexpr variant",
+      "licenseId": "HPND-sell-regexpr",
+      "seeAlso": [
+        "https://gitlab.com/bacula-org/bacula/-/blob/Branch-11.0/bacula/LICENSE-FOSS?ref_type\u003dheads#L245"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-sell-variant.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-sell-variant.json",
+      "referenceNumber": 13,
+      "name": "Historical Permission Notice and Disclaimer - sell variant",
+      "licenseId": "HPND-sell-variant",
+      "seeAlso": [
+        "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/net/sunrpc/auth_gss/gss_generic_token.c?h\u003dv4.19",
+        "https://github.com/kfish/xsel/blob/master/COPYING"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-sell-variant-MIT-disclaimer.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-sell-variant-MIT-disclaimer.json",
+      "referenceNumber": 225,
+      "name": "HPND sell variant with MIT disclaimer",
+      "licenseId": "HPND-sell-variant-MIT-disclaimer",
+      "seeAlso": [
+        "https://github.com/sigmavirus24/x11-ssh-askpass/blob/master/README"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-sell-variant-MIT-disclaimer-rev.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-sell-variant-MIT-disclaimer-rev.json",
+      "referenceNumber": 357,
+      "name": "HPND sell variant with MIT disclaimer - reverse",
+      "licenseId": "HPND-sell-variant-MIT-disclaimer-rev",
+      "seeAlso": [
+        "https://github.com/sigmavirus24/x11-ssh-askpass/blob/master/dynlist.c"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-UC.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-UC.json",
+      "referenceNumber": 210,
+      "name": "Historical Permission Notice and Disclaimer - University of California variant",
+      "licenseId": "HPND-UC",
+      "seeAlso": [
+        "https://core.tcl-lang.org/tk/file?name\u003dcompat/unistd.h"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HPND-UC-export-US.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HPND-UC-export-US.json",
+      "referenceNumber": 143,
+      "name": "Historical Permission Notice and Disclaimer - University of California, US export warning",
+      "licenseId": "HPND-UC-export-US",
+      "seeAlso": [
+        "https://github.com/RTimothyEdwards/magic/blob/master/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/HTMLTIDY.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/HTMLTIDY.json",
+      "referenceNumber": 478,
+      "name": "HTML Tidy License",
+      "licenseId": "HTMLTIDY",
+      "seeAlso": [
+        "https://github.com/htacg/tidy-html5/blob/next/README/LICENSE.md"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/IBM-pibs.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/IBM-pibs.json",
+      "referenceNumber": 242,
       "name": "IBM PowerPC Initialization and Boot Software",
       "licenseId": "IBM-pibs",
       "seeAlso": [
@@ -2252,75 +4407,61 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./ICU.html",
+      "reference": "https://spdx.org/licenses/ICU.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/ICU.json",
-      "referenceNumber": "168",
+      "detailsUrl": "https://spdx.org/licenses/ICU.json",
+      "referenceNumber": 289,
       "name": "ICU License",
       "licenseId": "ICU",
       "seeAlso": [
         "http://source.icu-project.org/repos/icu/icu/trunk/license.html"
       ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/IEC-Code-Components-EULA.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/IEC-Code-Components-EULA.json",
+      "referenceNumber": 399,
+      "name": "IEC    Code Components End-user licence agreement",
+      "licenseId": "IEC-Code-Components-EULA",
+      "seeAlso": [
+        "https://www.iec.ch/webstore/custserv/pdf/CC-EULA.pdf",
+        "https://www.iec.ch/CCv1",
+        "https://www.iec.ch/copyright"
+      ],
       "isOsiApproved": false
     },
     {
-      "reference": "./IJG.html",
+      "reference": "https://spdx.org/licenses/IJG.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/IJG.json",
-      "referenceNumber": "228",
+      "detailsUrl": "https://spdx.org/licenses/IJG.json",
+      "referenceNumber": 512,
       "name": "Independent JPEG Group License",
       "licenseId": "IJG",
       "seeAlso": [
         "http://dev.w3.org/cvsweb/Amaya/libjpeg/Attic/README?rev\u003d1.2"
       ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/IJG-short.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/IJG-short.json",
+      "referenceNumber": 694,
+      "name": "Independent JPEG Group License - short",
+      "licenseId": "IJG-short",
+      "seeAlso": [
+        "https://sourceforge.net/p/xmedcon/code/ci/master/tree/libs/ljpg/"
+      ],
       "isOsiApproved": false
     },
     {
-      "reference": "./IPA.html",
+      "reference": "https://spdx.org/licenses/ImageMagick.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/IPA.json",
-      "referenceNumber": "299",
-      "name": "IPA Font License",
-      "licenseId": "IPA",
-      "seeAlso": [
-        "https://opensource.org/licenses/IPA"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./IPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/IPL-1.0.json",
-      "referenceNumber": "298",
-      "name": "IBM Public License v1.0",
-      "licenseId": "IPL-1.0",
-      "seeAlso": [
-        "https://opensource.org/licenses/IPL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./ISC.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/ISC.json",
-      "referenceNumber": "341",
-      "name": "ISC License",
-      "licenseId": "ISC",
-      "seeAlso": [
-        "https://www.isc.org/downloads/software-support-policy/isc-license/",
-        "https://opensource.org/licenses/ISC"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./ImageMagick.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/ImageMagick.json",
-      "referenceNumber": "315",
+      "detailsUrl": "https://spdx.org/licenses/ImageMagick.json",
+      "referenceNumber": 472,
       "name": "ImageMagick License",
       "licenseId": "ImageMagick",
       "seeAlso": [
@@ -2329,24 +4470,37 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./Imlib2.html",
+      "reference": "https://spdx.org/licenses/iMatix.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Imlib2.json",
-      "referenceNumber": "129",
+      "detailsUrl": "https://spdx.org/licenses/iMatix.json",
+      "referenceNumber": 482,
+      "name": "iMatix Standard Function Library Agreement",
+      "licenseId": "iMatix",
+      "seeAlso": [
+        "http://legacy.imatix.com/html/sfl/sfl4.htm#license"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Imlib2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Imlib2.json",
+      "referenceNumber": 552,
       "name": "Imlib2 License",
       "licenseId": "Imlib2",
       "seeAlso": [
         "http://trac.enlightenment.org/e/browser/trunk/imlib2/COPYING",
         "https://git.enlightenment.org/legacy/imlib2.git/tree/COPYING"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": false,
+      "isFsfLibre": true
     },
     {
-      "reference": "./Info-ZIP.html",
+      "reference": "https://spdx.org/licenses/Info-ZIP.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Info-ZIP.json",
-      "referenceNumber": "273",
+      "detailsUrl": "https://spdx.org/licenses/Info-ZIP.json",
+      "referenceNumber": 52,
       "name": "Info-ZIP License",
       "licenseId": "Info-ZIP",
       "seeAlso": [
@@ -2355,23 +4509,48 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./Intel.html",
+      "reference": "https://spdx.org/licenses/Inner-Net-2.0.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Intel.json",
-      "referenceNumber": "27",
+      "detailsUrl": "https://spdx.org/licenses/Inner-Net-2.0.json",
+      "referenceNumber": 328,
+      "name": "Inner Net License v2.0",
+      "licenseId": "Inner-Net-2.0",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Inner_Net_License",
+        "https://sourceware.org/git/?p\u003dglibc.git;a\u003dblob;f\u003dLICENSES;h\u003d530893b1dc9ea00755603c68fb36bd4fc38a7be8;hb\u003dHEAD#l207"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/InnoSetup.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/InnoSetup.json",
+      "referenceNumber": 354,
+      "name": "Inno Setup License",
+      "licenseId": "InnoSetup",
+      "seeAlso": [
+        "https://github.com/jrsoftware/issrc/blob/HEAD/license.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Intel.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Intel.json",
+      "referenceNumber": 419,
       "name": "Intel Open Source License",
       "licenseId": "Intel",
       "seeAlso": [
         "https://opensource.org/licenses/Intel"
       ],
-      "isOsiApproved": true
+      "isOsiApproved": true,
+      "isFsfLibre": true
     },
     {
-      "reference": "./Intel-ACPI.html",
+      "reference": "https://spdx.org/licenses/Intel-ACPI.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Intel-ACPI.json",
-      "referenceNumber": "227",
+      "detailsUrl": "https://spdx.org/licenses/Intel-ACPI.json",
+      "referenceNumber": 206,
       "name": "Intel ACPI Software License Agreement",
       "licenseId": "Intel-ACPI",
       "seeAlso": [
@@ -2380,10 +4559,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./Interbase-1.0.html",
+      "reference": "https://spdx.org/licenses/Interbase-1.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Interbase-1.0.json",
-      "referenceNumber": "312",
+      "detailsUrl": "https://spdx.org/licenses/Interbase-1.0.json",
+      "referenceNumber": 532,
       "name": "Interbase Public License v1.0",
       "licenseId": "Interbase-1.0",
       "seeAlso": [
@@ -2392,34 +4571,78 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./JPNIC.html",
+      "reference": "https://spdx.org/licenses/IPA.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/JPNIC.json",
-      "referenceNumber": "305",
-      "name": "Japan Network Information Center License",
-      "licenseId": "JPNIC",
+      "detailsUrl": "https://spdx.org/licenses/IPA.json",
+      "referenceNumber": 186,
+      "name": "IPA Font License",
+      "licenseId": "IPA",
       "seeAlso": [
-        "https://gitlab.isc.org/isc-projects/bind9/blob/master/COPYRIGHT#L366"
+        "https://opensource.org/licenses/IPA"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/IPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/IPL-1.0.json",
+      "referenceNumber": 591,
+      "name": "IBM Public License v1.0",
+      "licenseId": "IPL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/IPL-1.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/ISC.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ISC.json",
+      "referenceNumber": 58,
+      "name": "ISC License",
+      "licenseId": "ISC",
+      "seeAlso": [
+        "https://www.isc.org/licenses/",
+        "https://www.isc.org/downloads/software-support-policy/isc-license/",
+        "https://opensource.org/licenses/ISC"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/ISC-Veillard.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ISC-Veillard.json",
+      "referenceNumber": 317,
+      "name": "ISC Veillard variant",
+      "licenseId": "ISC-Veillard",
+      "seeAlso": [
+        "https://raw.githubusercontent.com/GNOME/libxml2/4c2e7c651f6c2f0d1a74f350cbda95f7df3e7017/hash.c",
+        "https://github.com/GNOME/libxml2/blob/master/dict.c",
+        "https://sourceforge.net/p/ctrio/git/ci/master/tree/README"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./JSON.html",
+      "reference": "https://spdx.org/licenses/Jam.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/JSON.json",
-      "referenceNumber": "190",
-      "name": "JSON License",
-      "licenseId": "JSON",
+      "detailsUrl": "https://spdx.org/licenses/Jam.json",
+      "referenceNumber": 475,
+      "name": "Jam License",
+      "licenseId": "Jam",
       "seeAlso": [
-        "http://www.json.org/license.html"
+        "https://www.boost.org/doc/libs/1_35_0/doc/html/jam.html",
+        "https://web.archive.org/web/20160330173339/https://swarm.workshop.perforce.com/files/guest/perforce_software/jam/src/README"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": true
     },
     {
-      "reference": "./JasPer-2.0.html",
+      "reference": "https://spdx.org/licenses/JasPer-2.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/JasPer-2.0.json",
-      "referenceNumber": "72",
+      "detailsUrl": "https://spdx.org/licenses/JasPer-2.0.json",
+      "referenceNumber": 103,
       "name": "JasPer License",
       "licenseId": "JasPer-2.0",
       "seeAlso": [
@@ -2428,10 +4651,95 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./LAL-1.2.html",
+      "reference": "https://spdx.org/licenses/jove.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/LAL-1.2.json",
-      "referenceNumber": "147",
+      "detailsUrl": "https://spdx.org/licenses/jove.json",
+      "referenceNumber": 642,
+      "name": "Jove License",
+      "licenseId": "jove",
+      "seeAlso": [
+        "https://github.com/jonmacs/jove/blob/4_17/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/JPL-image.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/JPL-image.json",
+      "referenceNumber": 321,
+      "name": "JPL Image Use Policy",
+      "licenseId": "JPL-image",
+      "seeAlso": [
+        "https://www.jpl.nasa.gov/jpl-image-use-policy"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/JPNIC.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/JPNIC.json",
+      "referenceNumber": 655,
+      "name": "Japan Network Information Center License",
+      "licenseId": "JPNIC",
+      "seeAlso": [
+        "https://gitlab.isc.org/isc-projects/bind9/blob/master/COPYRIGHT#L366"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/JSON.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/JSON.json",
+      "referenceNumber": 54,
+      "name": "JSON License",
+      "licenseId": "JSON",
+      "seeAlso": [
+        "http://www.json.org/license.html"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Kastrup.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Kastrup.json",
+      "referenceNumber": 491,
+      "name": "Kastrup License",
+      "licenseId": "Kastrup",
+      "seeAlso": [
+        "https://ctan.math.utah.edu/ctan/tex-archive/macros/generic/kastrup/binhex.dtx"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Kazlib.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Kazlib.json",
+      "referenceNumber": 312,
+      "name": "Kazlib License",
+      "licenseId": "Kazlib",
+      "seeAlso": [
+        "http://git.savannah.gnu.org/cgit/kazlib.git/tree/except.c?id\u003d0062df360c2d17d57f6af19b0e444c51feb99036"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Knuth-CTAN.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Knuth-CTAN.json",
+      "referenceNumber": 332,
+      "name": "Knuth CTAN License",
+      "licenseId": "Knuth-CTAN",
+      "seeAlso": [
+        "https://ctan.org/license/knuth"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/LAL-1.2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LAL-1.2.json",
+      "referenceNumber": 134,
       "name": "Licence Art Libre 1.2",
       "licenseId": "LAL-1.2",
       "seeAlso": [
@@ -2440,283 +4748,22 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./LAL-1.3.html",
+      "reference": "https://spdx.org/licenses/LAL-1.3.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/LAL-1.3.json",
-      "referenceNumber": "345",
+      "detailsUrl": "https://spdx.org/licenses/LAL-1.3.json",
+      "referenceNumber": 521,
       "name": "Licence Art Libre 1.3",
       "licenseId": "LAL-1.3",
       "seeAlso": [
-        "http://artlibre.org/"
+        "https://artlibre.org/"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./LGPL-2.0.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "http://spdx.org/licenses/LGPL-2.0.json",
-      "referenceNumber": "266",
-      "name": "GNU Library General Public License v2 only",
-      "licenseId": "LGPL-2.0",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LGPL-2.0+.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "http://spdx.org/licenses/LGPL-2.0+.json",
-      "referenceNumber": "133",
-      "name": "GNU Library General Public License v2 or later",
-      "licenseId": "LGPL-2.0+",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LGPL-2.0-only.html",
+      "reference": "https://spdx.org/licenses/Latex2e.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/LGPL-2.0-only.json",
-      "referenceNumber": "317",
-      "name": "GNU Library General Public License v2 only",
-      "licenseId": "LGPL-2.0-only",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LGPL-2.0-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/LGPL-2.0-or-later.json",
-      "referenceNumber": "33",
-      "name": "GNU Library General Public License v2 or later",
-      "licenseId": "LGPL-2.0-or-later",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LGPL-2.1.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/LGPL-2.1.json",
-      "referenceNumber": "176",
-      "name": "GNU Lesser General Public License v2.1 only",
-      "licenseId": "LGPL-2.1",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
-        "https://opensource.org/licenses/LGPL-2.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LGPL-2.1+.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/LGPL-2.1+.json",
-      "referenceNumber": "194",
-      "name": "GNU Library General Public License v2.1 or later",
-      "licenseId": "LGPL-2.1+",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
-        "https://opensource.org/licenses/LGPL-2.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LGPL-2.1-only.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/LGPL-2.1-only.json",
-      "referenceNumber": "132",
-      "name": "GNU Lesser General Public License v2.1 only",
-      "licenseId": "LGPL-2.1-only",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
-        "https://opensource.org/licenses/LGPL-2.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LGPL-2.1-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/LGPL-2.1-or-later.json",
-      "referenceNumber": "259",
-      "name": "GNU Lesser General Public License v2.1 or later",
-      "licenseId": "LGPL-2.1-or-later",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
-        "https://opensource.org/licenses/LGPL-2.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LGPL-3.0.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/LGPL-3.0.json",
-      "referenceNumber": "201",
-      "name": "GNU Lesser General Public License v3.0 only",
-      "licenseId": "LGPL-3.0",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
-        "https://opensource.org/licenses/LGPL-3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LGPL-3.0+.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/LGPL-3.0+.json",
-      "referenceNumber": "212",
-      "name": "GNU Lesser General Public License v3.0 or later",
-      "licenseId": "LGPL-3.0+",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
-        "https://opensource.org/licenses/LGPL-3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LGPL-3.0-only.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/LGPL-3.0-only.json",
-      "referenceNumber": "44",
-      "name": "GNU Lesser General Public License v3.0 only",
-      "licenseId": "LGPL-3.0-only",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
-        "https://opensource.org/licenses/LGPL-3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LGPL-3.0-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/LGPL-3.0-or-later.json",
-      "referenceNumber": "306",
-      "name": "GNU Lesser General Public License v3.0 or later",
-      "licenseId": "LGPL-3.0-or-later",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
-        "https://opensource.org/licenses/LGPL-3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LGPLLR.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/LGPLLR.json",
-      "referenceNumber": "392",
-      "name": "Lesser General Public License For Linguistic Resources",
-      "licenseId": "LGPLLR",
-      "seeAlso": [
-        "http://www-igm.univ-mlv.fr/~unitex/lgpllr.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./LPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/LPL-1.0.json",
-      "referenceNumber": "359",
-      "name": "Lucent Public License Version 1.0",
-      "licenseId": "LPL-1.0",
-      "seeAlso": [
-        "https://opensource.org/licenses/LPL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LPL-1.02.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/LPL-1.02.json",
-      "referenceNumber": "114",
-      "name": "Lucent Public License v1.02",
-      "licenseId": "LPL-1.02",
-      "seeAlso": [
-        "http://plan9.bell-labs.com/plan9/license.html",
-        "https://opensource.org/licenses/LPL-1.02"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LPPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/LPPL-1.0.json",
-      "referenceNumber": "77",
-      "name": "LaTeX Project Public License v1.0",
-      "licenseId": "LPPL-1.0",
-      "seeAlso": [
-        "http://www.latex-project.org/lppl/lppl-1-0.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./LPPL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/LPPL-1.1.json",
-      "referenceNumber": "162",
-      "name": "LaTeX Project Public License v1.1",
-      "licenseId": "LPPL-1.1",
-      "seeAlso": [
-        "http://www.latex-project.org/lppl/lppl-1-1.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./LPPL-1.2.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/LPPL-1.2.json",
-      "referenceNumber": "154",
-      "name": "LaTeX Project Public License v1.2",
-      "licenseId": "LPPL-1.2",
-      "seeAlso": [
-        "http://www.latex-project.org/lppl/lppl-1-2.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./LPPL-1.3a.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/LPPL-1.3a.json",
-      "referenceNumber": "260",
-      "name": "LaTeX Project Public License v1.3a",
-      "licenseId": "LPPL-1.3a",
-      "seeAlso": [
-        "http://www.latex-project.org/lppl/lppl-1-3a.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./LPPL-1.3c.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/LPPL-1.3c.json",
-      "referenceNumber": "120",
-      "name": "LaTeX Project Public License v1.3c",
-      "licenseId": "LPPL-1.3c",
-      "seeAlso": [
-        "http://www.latex-project.org/lppl/lppl-1-3c.txt",
-        "https://opensource.org/licenses/LPPL-1.3c"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Latex2e.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Latex2e.json",
-      "referenceNumber": "35",
+      "detailsUrl": "https://spdx.org/licenses/Latex2e.json",
+      "referenceNumber": 43,
       "name": "Latex2e License",
       "licenseId": "Latex2e",
       "seeAlso": [
@@ -2725,10 +4772,22 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./Leptonica.html",
+      "reference": "https://spdx.org/licenses/Latex2e-translated-notice.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Leptonica.json",
-      "referenceNumber": "289",
+      "detailsUrl": "https://spdx.org/licenses/Latex2e-translated-notice.json",
+      "referenceNumber": 523,
+      "name": "Latex2e with translated notice permission",
+      "licenseId": "Latex2e-translated-notice",
+      "seeAlso": [
+        "https://git.savannah.gnu.org/cgit/indent.git/tree/doc/indent.texi?id\u003da74c6b4ee49397cf330b333da1042bffa60ed14f#n74"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Leptonica.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Leptonica.json",
+      "referenceNumber": 137,
       "name": "Leptonica License",
       "licenseId": "Leptonica",
       "seeAlso": [
@@ -2737,10 +4796,259 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./LiLiQ-P-1.1.html",
+      "reference": "https://spdx.org/licenses/LGPL-2.0.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/LGPL-2.0.json",
+      "referenceNumber": 676,
+      "name": "GNU Library General Public License v2 only",
+      "licenseId": "LGPL-2.0",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LGPL-2.0+.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/LGPL-2.0+.json",
+      "referenceNumber": 409,
+      "name": "GNU Library General Public License v2 or later",
+      "licenseId": "LGPL-2.0+",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LGPL-2.0-only.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/LiLiQ-P-1.1.json",
-      "referenceNumber": "74",
+      "detailsUrl": "https://spdx.org/licenses/LGPL-2.0-only.json",
+      "referenceNumber": 329,
+      "name": "GNU Library General Public License v2 only",
+      "licenseId": "LGPL-2.0-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LGPL-2.0-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LGPL-2.0-or-later.json",
+      "referenceNumber": 75,
+      "name": "GNU Library General Public License v2 or later",
+      "licenseId": "LGPL-2.0-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LGPL-2.1.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/LGPL-2.1.json",
+      "referenceNumber": 677,
+      "name": "GNU Lesser General Public License v2.1 only",
+      "licenseId": "LGPL-2.1",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+        "https://opensource.org/licenses/LGPL-2.1"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LGPL-2.1+.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/LGPL-2.1+.json",
+      "referenceNumber": 448,
+      "name": "GNU Lesser General Public License v2.1 or later",
+      "licenseId": "LGPL-2.1+",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+        "https://opensource.org/licenses/LGPL-2.1"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LGPL-2.1-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LGPL-2.1-only.json",
+      "referenceNumber": 297,
+      "name": "GNU Lesser General Public License v2.1 only",
+      "licenseId": "LGPL-2.1-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+        "https://opensource.org/licenses/LGPL-2.1"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LGPL-2.1-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LGPL-2.1-or-later.json",
+      "referenceNumber": 187,
+      "name": "GNU Lesser General Public License v2.1 or later",
+      "licenseId": "LGPL-2.1-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+        "https://opensource.org/licenses/LGPL-2.1"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LGPL-3.0.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/LGPL-3.0.json",
+      "referenceNumber": 9,
+      "name": "GNU Lesser General Public License v3.0 only",
+      "licenseId": "LGPL-3.0",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
+        "https://www.gnu.org/licenses/lgpl+gpl-3.0.txt",
+        "https://opensource.org/licenses/LGPL-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LGPL-3.0+.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/LGPL-3.0+.json",
+      "referenceNumber": 169,
+      "name": "GNU Lesser General Public License v3.0 or later",
+      "licenseId": "LGPL-3.0+",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
+        "https://www.gnu.org/licenses/lgpl+gpl-3.0.txt",
+        "https://opensource.org/licenses/LGPL-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LGPL-3.0-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LGPL-3.0-only.json",
+      "referenceNumber": 634,
+      "name": "GNU Lesser General Public License v3.0 only",
+      "licenseId": "LGPL-3.0-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
+        "https://www.gnu.org/licenses/lgpl+gpl-3.0.txt",
+        "https://opensource.org/licenses/LGPL-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LGPL-3.0-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LGPL-3.0-or-later.json",
+      "referenceNumber": 502,
+      "name": "GNU Lesser General Public License v3.0 or later",
+      "licenseId": "LGPL-3.0-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
+        "https://www.gnu.org/licenses/lgpl+gpl-3.0.txt",
+        "https://opensource.org/licenses/LGPL-3.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LGPLLR.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LGPLLR.json",
+      "referenceNumber": 123,
+      "name": "Lesser General Public License For Linguistic Resources",
+      "licenseId": "LGPLLR",
+      "seeAlso": [
+        "http://www-igm.univ-mlv.fr/~unitex/lgpllr.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Libpng.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Libpng.json",
+      "referenceNumber": 62,
+      "name": "libpng License",
+      "licenseId": "Libpng",
+      "seeAlso": [
+        "http://www.libpng.org/pub/png/src/libpng-LICENSE.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/libpng-1.6.35.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/libpng-1.6.35.json",
+      "referenceNumber": 429,
+      "name": "PNG Reference Library License v1 (for libpng 0.5 through 1.6.35)",
+      "licenseId": "libpng-1.6.35",
+      "seeAlso": [
+        "http://www.libpng.org/pub/png/src/libpng-LICENSE.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/libpng-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/libpng-2.0.json",
+      "referenceNumber": 226,
+      "name": "PNG Reference Library version 2",
+      "licenseId": "libpng-2.0",
+      "seeAlso": [
+        "http://www.libpng.org/pub/png/src/libpng-LICENSE.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/libselinux-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/libselinux-1.0.json",
+      "referenceNumber": 263,
+      "name": "libselinux public domain notice",
+      "licenseId": "libselinux-1.0",
+      "seeAlso": [
+        "https://github.com/SELinuxProject/selinux/blob/master/libselinux/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/libtiff.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/libtiff.json",
+      "referenceNumber": 35,
+      "name": "libtiff License",
+      "licenseId": "libtiff",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/libtiff"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/libutil-David-Nugent.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/libutil-David-Nugent.json",
+      "referenceNumber": 402,
+      "name": "libutil David Nugent License",
+      "licenseId": "libutil-David-Nugent",
+      "seeAlso": [
+        "http://web.mit.edu/freebsd/head/lib/libutil/login_ok.3",
+        "https://cgit.freedesktop.org/libbsd/tree/man/setproctitle.3bsd"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/LiLiQ-P-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LiLiQ-P-1.1.json",
+      "referenceNumber": 232,
       "name": "Licence Libre du Québec – Permissive version 1.1",
       "licenseId": "LiLiQ-P-1.1",
       "seeAlso": [
@@ -2750,10 +5058,10 @@
       "isOsiApproved": true
     },
     {
-      "reference": "./LiLiQ-R-1.1.html",
+      "reference": "https://spdx.org/licenses/LiLiQ-R-1.1.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/LiLiQ-R-1.1.json",
-      "referenceNumber": "280",
+      "detailsUrl": "https://spdx.org/licenses/LiLiQ-R-1.1.json",
+      "referenceNumber": 229,
       "name": "Licence Libre du Québec – Réciprocité version 1.1",
       "licenseId": "LiLiQ-R-1.1",
       "seeAlso": [
@@ -2763,10 +5071,10 @@
       "isOsiApproved": true
     },
     {
-      "reference": "./LiLiQ-Rplus-1.1.html",
+      "reference": "https://spdx.org/licenses/LiLiQ-Rplus-1.1.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/LiLiQ-Rplus-1.1.json",
-      "referenceNumber": "324",
+      "detailsUrl": "https://spdx.org/licenses/LiLiQ-Rplus-1.1.json",
+      "referenceNumber": 238,
       "name": "Licence Libre du Québec – Réciprocité forte version 1.1",
       "licenseId": "LiLiQ-Rplus-1.1",
       "seeAlso": [
@@ -2776,22 +5084,59 @@
       "isOsiApproved": true
     },
     {
-      "reference": "./Libpng.html",
+      "reference": "https://spdx.org/licenses/Linux-man-pages-1-para.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Libpng.json",
-      "referenceNumber": "364",
-      "name": "libpng License",
-      "licenseId": "Libpng",
+      "detailsUrl": "https://spdx.org/licenses/Linux-man-pages-1-para.json",
+      "referenceNumber": 78,
+      "name": "Linux man-pages - 1 paragraph",
+      "licenseId": "Linux-man-pages-1-para",
       "seeAlso": [
-        "http://www.libpng.org/pub/png/src/libpng-LICENSE.txt"
+        "https://git.kernel.org/pub/scm/docs/man-pages/man-pages.git/tree/man2/getcpu.2#n4"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./Linux-OpenIB.html",
+      "reference": "https://spdx.org/licenses/Linux-man-pages-copyleft.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Linux-OpenIB.json",
-      "referenceNumber": "209",
+      "detailsUrl": "https://spdx.org/licenses/Linux-man-pages-copyleft.json",
+      "referenceNumber": 640,
+      "name": "Linux man-pages Copyleft",
+      "licenseId": "Linux-man-pages-copyleft",
+      "seeAlso": [
+        "https://www.kernel.org/doc/man-pages/licenses.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Linux-man-pages-copyleft-2-para.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Linux-man-pages-copyleft-2-para.json",
+      "referenceNumber": 592,
+      "name": "Linux man-pages Copyleft - 2 paragraphs",
+      "licenseId": "Linux-man-pages-copyleft-2-para",
+      "seeAlso": [
+        "https://git.kernel.org/pub/scm/docs/man-pages/man-pages.git/tree/man2/move_pages.2#n5",
+        "https://git.kernel.org/pub/scm/docs/man-pages/man-pages.git/tree/man2/migrate_pages.2#n8"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Linux-man-pages-copyleft-var.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Linux-man-pages-copyleft-var.json",
+      "referenceNumber": 202,
+      "name": "Linux man-pages Copyleft Variant",
+      "licenseId": "Linux-man-pages-copyleft-var",
+      "seeAlso": [
+        "https://git.kernel.org/pub/scm/docs/man-pages/man-pages.git/tree/man2/set_mempolicy.2#n5"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Linux-OpenIB.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Linux-OpenIB.json",
+      "referenceNumber": 513,
       "name": "Linux Kernel Variant of OpenIB.org license",
       "licenseId": "Linux-OpenIB",
       "seeAlso": [
@@ -2800,23 +5145,341 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./MIT.html",
+      "reference": "https://spdx.org/licenses/LOOP.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/MIT.json",
-      "referenceNumber": "247",
-      "name": "MIT License",
-      "licenseId": "MIT",
+      "detailsUrl": "https://spdx.org/licenses/LOOP.json",
+      "referenceNumber": 237,
+      "name": "Common Lisp LOOP License",
+      "licenseId": "LOOP",
       "seeAlso": [
-        "https://opensource.org/licenses/MIT"
+        "https://gitlab.com/embeddable-common-lisp/ecl/-/blob/develop/src/lsp/loop.lsp",
+        "http://git.savannah.gnu.org/cgit/gcl.git/tree/gcl/lsp/gcl_loop.lsp?h\u003dVersion_2_6_13pre",
+        "https://sourceforge.net/p/sbcl/sbcl/ci/master/tree/src/code/loop.lisp",
+        "https://github.com/cl-adams/adams/blob/master/LICENSE.md",
+        "https://github.com/blakemcbride/eclipse-lisp/blob/master/lisp/loop.lisp",
+        "https://gitlab.common-lisp.net/cmucl/cmucl/-/blob/master/src/code/loop.lisp"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/LPD-document.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LPD-document.json",
+      "referenceNumber": 5,
+      "name": "LPD Documentation License",
+      "licenseId": "LPD-document",
+      "seeAlso": [
+        "https://github.com/Cyan4973/xxHash/blob/dev/doc/xxhash_spec.md",
+        "https://www.ietf.org/rfc/rfc1952.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/LPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LPL-1.0.json",
+      "referenceNumber": 136,
+      "name": "Lucent Public License Version 1.0",
+      "licenseId": "LPL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/LPL-1.0"
       ],
       "isOsiApproved": true
     },
     {
-      "reference": "./MIT-0.html",
+      "reference": "https://spdx.org/licenses/LPL-1.02.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/MIT-0.json",
-      "referenceNumber": "71",
+      "detailsUrl": "https://spdx.org/licenses/LPL-1.02.json",
+      "referenceNumber": 656,
+      "name": "Lucent Public License v1.02",
+      "licenseId": "LPL-1.02",
+      "seeAlso": [
+        "http://plan9.bell-labs.com/plan9/license.html",
+        "https://opensource.org/licenses/LPL-1.02"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LPPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LPPL-1.0.json",
+      "referenceNumber": 63,
+      "name": "LaTeX Project Public License v1.0",
+      "licenseId": "LPPL-1.0",
+      "seeAlso": [
+        "http://www.latex-project.org/lppl/lppl-1-0.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/LPPL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LPPL-1.1.json",
+      "referenceNumber": 542,
+      "name": "LaTeX Project Public License v1.1",
+      "licenseId": "LPPL-1.1",
+      "seeAlso": [
+        "http://www.latex-project.org/lppl/lppl-1-1.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/LPPL-1.2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LPPL-1.2.json",
+      "referenceNumber": 486,
+      "name": "LaTeX Project Public License v1.2",
+      "licenseId": "LPPL-1.2",
+      "seeAlso": [
+        "http://www.latex-project.org/lppl/lppl-1-2.txt"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LPPL-1.3a.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LPPL-1.3a.json",
+      "referenceNumber": 280,
+      "name": "LaTeX Project Public License v1.3a",
+      "licenseId": "LPPL-1.3a",
+      "seeAlso": [
+        "http://www.latex-project.org/lppl/lppl-1-3a.txt"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/LPPL-1.3c.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LPPL-1.3c.json",
+      "referenceNumber": 33,
+      "name": "LaTeX Project Public License v1.3c",
+      "licenseId": "LPPL-1.3c",
+      "seeAlso": [
+        "http://www.latex-project.org/lppl/lppl-1-3c.txt",
+        "https://opensource.org/licenses/LPPL-1.3c"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/lsof.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/lsof.json",
+      "referenceNumber": 563,
+      "name": "lsof License",
+      "licenseId": "lsof",
+      "seeAlso": [
+        "https://github.com/lsof-org/lsof/blob/master/COPYING"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Lucida-Bitmap-Fonts.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Lucida-Bitmap-Fonts.json",
+      "referenceNumber": 661,
+      "name": "Lucida Bitmap Fonts License",
+      "licenseId": "Lucida-Bitmap-Fonts",
+      "seeAlso": [
+        "https://gitlab.freedesktop.org/xorg/font/bh-100dpi/-/blob/master/COPYING?ref_type\u003dheads"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/LZMA-SDK-9.11-to-9.20.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LZMA-SDK-9.11-to-9.20.json",
+      "referenceNumber": 349,
+      "name": "LZMA SDK License (versions 9.11 to 9.20)",
+      "licenseId": "LZMA-SDK-9.11-to-9.20",
+      "seeAlso": [
+        "https://www.7-zip.org/sdk.html",
+        "https://sourceforge.net/projects/sevenzip/files/LZMA%20SDK/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/LZMA-SDK-9.22.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/LZMA-SDK-9.22.json",
+      "referenceNumber": 504,
+      "name": "LZMA SDK License (versions 9.22 and beyond)",
+      "licenseId": "LZMA-SDK-9.22",
+      "seeAlso": [
+        "https://www.7-zip.org/sdk.html",
+        "https://sourceforge.net/projects/sevenzip/files/LZMA%20SDK/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Mackerras-3-Clause.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Mackerras-3-Clause.json",
+      "referenceNumber": 539,
+      "name": "Mackerras 3-Clause License",
+      "licenseId": "Mackerras-3-Clause",
+      "seeAlso": [
+        "https://github.com/ppp-project/ppp/blob/master/pppd/chap_ms.c#L6-L28"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Mackerras-3-Clause-acknowledgment.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Mackerras-3-Clause-acknowledgment.json",
+      "referenceNumber": 433,
+      "name": "Mackerras 3-Clause - acknowledgment variant",
+      "licenseId": "Mackerras-3-Clause-acknowledgment",
+      "seeAlso": [
+        "https://github.com/ppp-project/ppp/blob/master/pppd/auth.c#L6-L28"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/magaz.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/magaz.json",
+      "referenceNumber": 373,
+      "name": "magaz License",
+      "licenseId": "magaz",
+      "seeAlso": [
+        "https://mirrors.nic.cz/tex-archive/macros/latex/contrib/magaz/magaz.tex",
+        "https://mirrors.ctan.org/macros/latex/contrib/version/version.sty"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/mailprio.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/mailprio.json",
+      "referenceNumber": 381,
+      "name": "mailprio License",
+      "licenseId": "mailprio",
+      "seeAlso": [
+        "https://fossies.org/linux/sendmail/contrib/mailprio"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MakeIndex.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MakeIndex.json",
+      "referenceNumber": 165,
+      "name": "MakeIndex License",
+      "licenseId": "MakeIndex",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/MakeIndex"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/man2html.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/man2html.json",
+      "referenceNumber": 120,
+      "name": "man2html License",
+      "licenseId": "man2html",
+      "seeAlso": [
+        "http://primates.ximian.com/~flucifredi/man/man-1.6g.tar.gz",
+        "https://github.com/hamano/man2html/blob/master/man2html.c",
+        "https://docs.oracle.com/cd/E81115_01/html/E81116/licenses.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Martin-Birgmeier.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Martin-Birgmeier.json",
+      "referenceNumber": 361,
+      "name": "Martin Birgmeier License",
+      "licenseId": "Martin-Birgmeier",
+      "seeAlso": [
+        "https://github.com/Perl/perl5/blob/blead/util.c#L6136"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/McPhee-slideshow.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/McPhee-slideshow.json",
+      "referenceNumber": 489,
+      "name": "McPhee Slideshow License",
+      "licenseId": "McPhee-slideshow",
+      "seeAlso": [
+        "https://mirror.las.iastate.edu/tex-archive/graphics/metapost/contrib/macros/slideshow/slideshow.mp"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/metamail.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/metamail.json",
+      "referenceNumber": 455,
+      "name": "metamail License",
+      "licenseId": "metamail",
+      "seeAlso": [
+        "https://github.com/Dual-Life/mime-base64/blob/master/Base64.xs#L12"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Minpack.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Minpack.json",
+      "referenceNumber": 28,
+      "name": "Minpack License",
+      "licenseId": "Minpack",
+      "seeAlso": [
+        "http://www.netlib.org/minpack/disclaimer",
+        "https://gitlab.com/libeigen/eigen/-/blob/master/COPYING.MINPACK"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MIPS.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MIPS.json",
+      "referenceNumber": 351,
+      "name": "MIPS License",
+      "licenseId": "MIPS",
+      "seeAlso": [
+        "https://sourceware.org/cgit/binutils-gdb/tree/include/coff/sym.h#n11"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MirOS.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MirOS.json",
+      "referenceNumber": 692,
+      "name": "The MirOS Licence",
+      "licenseId": "MirOS",
+      "seeAlso": [
+        "https://opensource.org/licenses/MirOS"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/MIT.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MIT.json",
+      "referenceNumber": 515,
+      "name": "MIT License",
+      "licenseId": "MIT",
+      "seeAlso": [
+        "https://opensource.org/license/mit/",
+        "http://opensource.org/licenses/MIT"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/MIT-0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MIT-0.json",
+      "referenceNumber": 173,
       "name": "MIT No Attribution",
       "licenseId": "MIT-0",
       "seeAlso": [
@@ -2827,10 +5490,34 @@
       "isOsiApproved": true
     },
     {
-      "reference": "./MIT-CMU.html",
+      "reference": "https://spdx.org/licenses/MIT-advertising.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/MIT-CMU.json",
-      "referenceNumber": "333",
+      "detailsUrl": "https://spdx.org/licenses/MIT-advertising.json",
+      "referenceNumber": 440,
+      "name": "Enlightenment License (e16)",
+      "licenseId": "MIT-advertising",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/MIT_With_Advertising"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MIT-Click.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MIT-Click.json",
+      "referenceNumber": 438,
+      "name": "MIT Click License",
+      "licenseId": "MIT-Click",
+      "seeAlso": [
+        "https://github.com/kohler/t1utils/blob/master/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MIT-CMU.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MIT-CMU.json",
+      "referenceNumber": 287,
       "name": "CMU License",
       "licenseId": "MIT-CMU",
       "seeAlso": [
@@ -2840,22 +5527,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./MIT-advertising.html",
+      "reference": "https://spdx.org/licenses/MIT-enna.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/MIT-advertising.json",
-      "referenceNumber": "185",
-      "name": "Enlightenment License (e16)",
-      "licenseId": "MIT-advertising",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/MIT_With_Advertising"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./MIT-enna.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/MIT-enna.json",
-      "referenceNumber": "49",
+      "detailsUrl": "https://spdx.org/licenses/MIT-enna.json",
+      "referenceNumber": 580,
       "name": "enna License",
       "licenseId": "MIT-enna",
       "seeAlso": [
@@ -2864,10 +5539,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./MIT-feh.html",
+      "reference": "https://spdx.org/licenses/MIT-feh.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/MIT-feh.json",
-      "referenceNumber": "353",
+      "detailsUrl": "https://spdx.org/licenses/MIT-feh.json",
+      "referenceNumber": 408,
       "name": "feh License",
       "licenseId": "MIT-feh",
       "seeAlso": [
@@ -2876,10 +5551,87 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./MITNFA.html",
+      "reference": "https://spdx.org/licenses/MIT-Festival.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/MITNFA.json",
-      "referenceNumber": "325",
+      "detailsUrl": "https://spdx.org/licenses/MIT-Festival.json",
+      "referenceNumber": 18,
+      "name": "MIT Festival Variant",
+      "licenseId": "MIT-Festival",
+      "seeAlso": [
+        "https://github.com/festvox/flite/blob/master/COPYING",
+        "https://github.com/festvox/speech_tools/blob/master/COPYING"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MIT-Khronos-old.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MIT-Khronos-old.json",
+      "referenceNumber": 508,
+      "name": "MIT Khronos - old variant",
+      "licenseId": "MIT-Khronos-old",
+      "seeAlso": [
+        "https://github.com/KhronosGroup/SPIRV-Cross/blob/main/LICENSES/LicenseRef-KhronosFreeUse.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MIT-Modern-Variant.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MIT-Modern-Variant.json",
+      "referenceNumber": 304,
+      "name": "MIT License Modern Variant",
+      "licenseId": "MIT-Modern-Variant",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing:MIT#Modern_Variants",
+        "https://ptolemy.berkeley.edu/copyright.htm",
+        "https://pirlwww.lpl.arizona.edu/resources/guide/software/PerlTk/Tixlic.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/MIT-open-group.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MIT-open-group.json",
+      "referenceNumber": 404,
+      "name": "MIT Open Group variant",
+      "licenseId": "MIT-open-group",
+      "seeAlso": [
+        "https://gitlab.freedesktop.org/xorg/app/iceauth/-/blob/master/COPYING",
+        "https://gitlab.freedesktop.org/xorg/app/xsetroot/-/blob/master/COPYING",
+        "https://gitlab.freedesktop.org/xorg/app/xauth/-/blob/master/COPYING"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MIT-testregex.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MIT-testregex.json",
+      "referenceNumber": 496,
+      "name": "MIT testregex Variant",
+      "licenseId": "MIT-testregex",
+      "seeAlso": [
+        "https://github.com/dotnet/runtime/blob/55e1ac7c07df62c4108d4acedf78f77574470ce5/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/AttRegexTests.cs#L12-L28"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MIT-Wu.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MIT-Wu.json",
+      "referenceNumber": 355,
+      "name": "MIT Tom Wu Variant",
+      "licenseId": "MIT-Wu",
+      "seeAlso": [
+        "https://github.com/chromium/octane/blob/master/crypto.js"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MITNFA.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MITNFA.json",
+      "referenceNumber": 473,
       "name": "MIT +no-false-attribs license",
       "licenseId": "MITNFA",
       "seeAlso": [
@@ -2888,10 +5640,70 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./MPL-1.0.html",
+      "reference": "https://spdx.org/licenses/MMIXware.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/MPL-1.0.json",
-      "referenceNumber": "230",
+      "detailsUrl": "https://spdx.org/licenses/MMIXware.json",
+      "referenceNumber": 663,
+      "name": "MMIXware License",
+      "licenseId": "MMIXware",
+      "seeAlso": [
+        "https://gitlab.lrz.de/mmix/mmixware/-/blob/master/boilerplate.w"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Motosoto.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Motosoto.json",
+      "referenceNumber": 507,
+      "name": "Motosoto License",
+      "licenseId": "Motosoto",
+      "seeAlso": [
+        "https://opensource.org/licenses/Motosoto"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/MPEG-SSG.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MPEG-SSG.json",
+      "referenceNumber": 303,
+      "name": "MPEG Software Simulation",
+      "licenseId": "MPEG-SSG",
+      "seeAlso": [
+        "https://sourceforge.net/p/netpbm/code/HEAD/tree/super_stable/converter/ppm/ppmtompeg/jrevdct.c#l1189"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/mpi-permissive.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/mpi-permissive.json",
+      "referenceNumber": 213,
+      "name": "mpi Permissive License",
+      "licenseId": "mpi-permissive",
+      "seeAlso": [
+        "https://sources.debian.org/src/openmpi/4.1.0-10/ompi/debuggers/msgq_interface.h/?hl\u003d19#L19"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/mpich2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/mpich2.json",
+      "referenceNumber": 102,
+      "name": "mpich2 License",
+      "licenseId": "mpich2",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/MIT"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MPL-1.0.json",
+      "referenceNumber": 665,
       "name": "Mozilla Public License 1.0",
       "licenseId": "MPL-1.0",
       "seeAlso": [
@@ -2901,79 +5713,105 @@
       "isOsiApproved": true
     },
     {
-      "reference": "./MPL-1.1.html",
+      "reference": "https://spdx.org/licenses/MPL-1.1.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/MPL-1.1.json",
-      "referenceNumber": "382",
+      "detailsUrl": "https://spdx.org/licenses/MPL-1.1.json",
+      "referenceNumber": 679,
       "name": "Mozilla Public License 1.1",
       "licenseId": "MPL-1.1",
       "seeAlso": [
         "http://www.mozilla.org/MPL/MPL-1.1.html",
         "https://opensource.org/licenses/MPL-1.1"
       ],
-      "isOsiApproved": true
+      "isOsiApproved": true,
+      "isFsfLibre": true
     },
     {
-      "reference": "./MPL-2.0.html",
+      "reference": "https://spdx.org/licenses/MPL-2.0.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/MPL-2.0.json",
-      "referenceNumber": "115",
+      "detailsUrl": "https://spdx.org/licenses/MPL-2.0.json",
+      "referenceNumber": 599,
       "name": "Mozilla Public License 2.0",
       "licenseId": "MPL-2.0",
       "seeAlso": [
-        "http://www.mozilla.org/MPL/2.0/",
+        "https://www.mozilla.org/MPL/2.0/",
         "https://opensource.org/licenses/MPL-2.0"
       ],
-      "isOsiApproved": true
+      "isOsiApproved": true,
+      "isFsfLibre": true
     },
     {
-      "reference": "./MPL-2.0-no-copyleft-exception.html",
+      "reference": "https://spdx.org/licenses/MPL-2.0-no-copyleft-exception.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/MPL-2.0-no-copyleft-exception.json",
-      "referenceNumber": "177",
+      "detailsUrl": "https://spdx.org/licenses/MPL-2.0-no-copyleft-exception.json",
+      "referenceNumber": 174,
       "name": "Mozilla Public License 2.0 (no copyleft exception)",
       "licenseId": "MPL-2.0-no-copyleft-exception",
       "seeAlso": [
-        "http://www.mozilla.org/MPL/2.0/",
+        "https://www.mozilla.org/MPL/2.0/",
         "https://opensource.org/licenses/MPL-2.0"
       ],
       "isOsiApproved": true
     },
     {
-      "reference": "./MS-PL.html",
+      "reference": "https://spdx.org/licenses/mplus.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/MS-PL.json",
-      "referenceNumber": "354",
+      "detailsUrl": "https://spdx.org/licenses/mplus.json",
+      "referenceNumber": 17,
+      "name": "mplus Font License",
+      "licenseId": "mplus",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing:Mplus?rd\u003dLicensing/mplus"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MS-LPL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MS-LPL.json",
+      "referenceNumber": 674,
+      "name": "Microsoft Limited Public License",
+      "licenseId": "MS-LPL",
+      "seeAlso": [
+        "https://www.openhub.net/licenses/mslpl",
+        "https://github.com/gabegundy/atlserver/blob/master/License.txt",
+        "https://en.wikipedia.org/wiki/Shared_Source_Initiative#Microsoft_Limited_Public_License_(Ms-LPL)"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/MS-PL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MS-PL.json",
+      "referenceNumber": 698,
       "name": "Microsoft Public License",
       "licenseId": "MS-PL",
       "seeAlso": [
         "http://www.microsoft.com/opensource/licenses.mspx",
         "https://opensource.org/licenses/MS-PL"
       ],
-      "isOsiApproved": true
+      "isOsiApproved": true,
+      "isFsfLibre": true
     },
     {
-      "reference": "./MS-RL.html",
+      "reference": "https://spdx.org/licenses/MS-RL.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/MS-RL.json",
-      "referenceNumber": "4",
+      "detailsUrl": "https://spdx.org/licenses/MS-RL.json",
+      "referenceNumber": 276,
       "name": "Microsoft Reciprocal License",
       "licenseId": "MS-RL",
       "seeAlso": [
         "http://www.microsoft.com/opensource/licenses.mspx",
         "https://opensource.org/licenses/MS-RL"
       ],
-      "isOsiApproved": true
+      "isOsiApproved": true,
+      "isFsfLibre": true
     },
     {
-      "reference": "./MTLL.html",
+      "reference": "https://spdx.org/licenses/MTLL.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/MTLL.json",
-      "referenceNumber": "96",
+      "detailsUrl": "https://spdx.org/licenses/MTLL.json",
+      "referenceNumber": 588,
       "name": "Matrix Template Library License",
       "licenseId": "MTLL",
       "seeAlso": [
@@ -2982,46 +5820,35 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./MakeIndex.html",
+      "reference": "https://spdx.org/licenses/MulanPSL-1.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/MakeIndex.json",
-      "referenceNumber": "332",
-      "name": "MakeIndex License",
-      "licenseId": "MakeIndex",
+      "detailsUrl": "https://spdx.org/licenses/MulanPSL-1.0.json",
+      "referenceNumber": 320,
+      "name": "Mulan Permissive Software License, Version 1",
+      "licenseId": "MulanPSL-1.0",
       "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/MakeIndex"
+        "https://license.coscl.org.cn/MulanPSL/",
+        "https://github.com/yuwenlong/longphp/blob/25dfb70cc2a466dc4bb55ba30901cbce08d164b5/LICENSE"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./MirOS.html",
+      "reference": "https://spdx.org/licenses/MulanPSL-2.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/MirOS.json",
-      "referenceNumber": "357",
-      "name": "MirOS License",
-      "licenseId": "MirOS",
+      "detailsUrl": "https://spdx.org/licenses/MulanPSL-2.0.json",
+      "referenceNumber": 182,
+      "name": "Mulan Permissive Software License, Version 2",
+      "licenseId": "MulanPSL-2.0",
       "seeAlso": [
-        "https://opensource.org/licenses/MirOS"
+        "https://license.coscl.org.cn/MulanPSL2"
       ],
       "isOsiApproved": true
     },
     {
-      "reference": "./Motosoto.html",
+      "reference": "https://spdx.org/licenses/Multics.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Motosoto.json",
-      "referenceNumber": "12",
-      "name": "Motosoto License",
-      "licenseId": "Motosoto",
-      "seeAlso": [
-        "https://opensource.org/licenses/Motosoto"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Multics.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Multics.json",
-      "referenceNumber": "158",
+      "detailsUrl": "https://spdx.org/licenses/Multics.json",
+      "referenceNumber": 60,
       "name": "Multics License",
       "licenseId": "Multics",
       "seeAlso": [
@@ -3030,10 +5857,10 @@
       "isOsiApproved": true
     },
     {
-      "reference": "./Mup.html",
+      "reference": "https://spdx.org/licenses/Mup.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Mup.json",
-      "referenceNumber": "294",
+      "detailsUrl": "https://spdx.org/licenses/Mup.json",
+      "referenceNumber": 288,
       "name": "Mup License",
       "licenseId": "Mup",
       "seeAlso": [
@@ -3042,160 +5869,37 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./NASA-1.3.html",
+      "reference": "https://spdx.org/licenses/NAIST-2003.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/NASA-1.3.json",
-      "referenceNumber": "104",
+      "detailsUrl": "https://spdx.org/licenses/NAIST-2003.json",
+      "referenceNumber": 462,
+      "name": "Nara Institute of Science and Technology License (2003)",
+      "licenseId": "NAIST-2003",
+      "seeAlso": [
+        "https://enterprise.dejacode.com/licenses/public/naist-2003/#license-text",
+        "https://github.com/nodejs/node/blob/4a19cc8947b1bba2b2d27816ec3d0edf9b28e503/LICENSE#L343"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/NASA-1.3.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NASA-1.3.json",
+      "referenceNumber": 432,
       "name": "NASA Open Source Agreement 1.3",
       "licenseId": "NASA-1.3",
       "seeAlso": [
         "http://ti.arc.nasa.gov/opensource/nosa/",
         "https://opensource.org/licenses/NASA-1.3"
       ],
-      "isOsiApproved": true
+      "isOsiApproved": true,
+      "isFsfLibre": false
     },
     {
-      "reference": "./NBPL-1.0.html",
+      "reference": "https://spdx.org/licenses/Naumen.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/NBPL-1.0.json",
-      "referenceNumber": "17",
-      "name": "Net Boolean Public License v1",
-      "licenseId": "NBPL-1.0",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d37b4b3f6cc4bf34e1d3dec61e69914b9819d8894"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./NCSA.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/NCSA.json",
-      "referenceNumber": "180",
-      "name": "University of Illinois/NCSA Open Source License",
-      "licenseId": "NCSA",
-      "seeAlso": [
-        "http://otm.illinois.edu/uiuc_openSource",
-        "https://opensource.org/licenses/NCSA"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./NGPL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/NGPL.json",
-      "referenceNumber": "297",
-      "name": "Nethack General Public License",
-      "licenseId": "NGPL",
-      "seeAlso": [
-        "https://opensource.org/licenses/NGPL"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./NLOD-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/NLOD-1.0.json",
-      "referenceNumber": "128",
-      "name": "Norwegian Licence for Open Government Data",
-      "licenseId": "NLOD-1.0",
-      "seeAlso": [
-        "http://data.norge.no/nlod/en/1.0"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./NLPL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/NLPL.json",
-      "referenceNumber": "295",
-      "name": "No Limit Public License",
-      "licenseId": "NLPL",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/NLPL"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./NOSL.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/NOSL.json",
-      "referenceNumber": "368",
-      "name": "Netizen Open Source License",
-      "licenseId": "NOSL",
-      "seeAlso": [
-        "http://bits.netizen.com.au/licenses/NOSL/nosl.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./NPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/NPL-1.0.json",
-      "referenceNumber": "236",
-      "name": "Netscape Public License v1.0",
-      "licenseId": "NPL-1.0",
-      "seeAlso": [
-        "http://www.mozilla.org/MPL/NPL/1.0/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./NPL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/NPL-1.1.json",
-      "referenceNumber": "397",
-      "name": "Netscape Public License v1.1",
-      "licenseId": "NPL-1.1",
-      "seeAlso": [
-        "http://www.mozilla.org/MPL/NPL/1.1/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./NPOSL-3.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/NPOSL-3.0.json",
-      "referenceNumber": "144",
-      "name": "Non-Profit Open Software License 3.0",
-      "licenseId": "NPOSL-3.0",
-      "seeAlso": [
-        "https://opensource.org/licenses/NOSL3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./NRL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/NRL.json",
-      "referenceNumber": "95",
-      "name": "NRL License",
-      "licenseId": "NRL",
-      "seeAlso": [
-        "http://web.mit.edu/network/isakmp/nrllicense.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./NTP.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/NTP.json",
-      "referenceNumber": "249",
-      "name": "NTP License",
-      "licenseId": "NTP",
-      "seeAlso": [
-        "https://opensource.org/licenses/NTP"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Naumen.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Naumen.json",
-      "referenceNumber": "272",
+      "detailsUrl": "https://spdx.org/licenses/Naumen.json",
+      "referenceNumber": 307,
       "name": "Naumen Public License",
       "licenseId": "Naumen",
       "seeAlso": [
@@ -3204,10 +5908,76 @@
       "isOsiApproved": true
     },
     {
-      "reference": "./Net-SNMP.html",
+      "reference": "https://spdx.org/licenses/NBPL-1.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Net-SNMP.json",
-      "referenceNumber": "268",
+      "detailsUrl": "https://spdx.org/licenses/NBPL-1.0.json",
+      "referenceNumber": 460,
+      "name": "Net Boolean Public License v1",
+      "licenseId": "NBPL-1.0",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d37b4b3f6cc4bf34e1d3dec61e69914b9819d8894"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/NCBI-PD.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NCBI-PD.json",
+      "referenceNumber": 696,
+      "name": "NCBI Public Domain Notice",
+      "licenseId": "NCBI-PD",
+      "seeAlso": [
+        "https://github.com/ncbi/sra-tools/blob/e8e5b6af4edc460156ad9ce5902d0779cffbf685/LICENSE",
+        "https://github.com/ncbi/datasets/blob/0ea4cd16b61e5b799d9cc55aecfa016d6c9bd2bf/LICENSE.md",
+        "https://github.com/ncbi/gprobe/blob/de64d30fee8b4c4013094d7d3139ea89b5dd1ace/LICENSE",
+        "https://github.com/ncbi/egapx/blob/08930b9dec0c69b2d1a05e5153c7b95ef0a3eb0f/LICENSE",
+        "https://github.com/ncbi/datasets/blob/master/LICENSE.md"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/NCGL-UK-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NCGL-UK-2.0.json",
+      "referenceNumber": 392,
+      "name": "Non-Commercial Government Licence",
+      "licenseId": "NCGL-UK-2.0",
+      "seeAlso": [
+        "http://www.nationalarchives.gov.uk/doc/non-commercial-government-licence/version/2/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/NCL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NCL.json",
+      "referenceNumber": 154,
+      "name": "NCL Source Code License",
+      "licenseId": "NCL",
+      "seeAlso": [
+        "https://gitlab.freedesktop.org/pipewire/pipewire/-/blob/master/src/modules/module-filter-chain/pffft.c?ref_type\u003dheads#L1-52"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/NCSA.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NCSA.json",
+      "referenceNumber": 148,
+      "name": "University of Illinois/NCSA Open Source License",
+      "licenseId": "NCSA",
+      "seeAlso": [
+        "http://otm.illinois.edu/uiuc_openSource",
+        "https://opensource.org/licenses/NCSA"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Net-SNMP.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/Net-SNMP.json",
+      "referenceNumber": 638,
       "name": "Net-SNMP License",
       "licenseId": "Net-SNMP",
       "seeAlso": [
@@ -3216,10 +5986,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./NetCDF.html",
+      "reference": "https://spdx.org/licenses/NetCDF.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/NetCDF.json",
-      "referenceNumber": "204",
+      "detailsUrl": "https://spdx.org/licenses/NetCDF.json",
+      "referenceNumber": 626,
       "name": "NetCDF license",
       "licenseId": "NetCDF",
       "seeAlso": [
@@ -3228,10 +5998,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./Newsletr.html",
+      "reference": "https://spdx.org/licenses/Newsletr.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Newsletr.json",
-      "referenceNumber": "346",
+      "detailsUrl": "https://spdx.org/licenses/Newsletr.json",
+      "referenceNumber": 607,
       "name": "Newsletr License",
       "licenseId": "Newsletr",
       "seeAlso": [
@@ -3240,23 +6010,146 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./Nokia.html",
+      "reference": "https://spdx.org/licenses/NGPL.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Nokia.json",
-      "referenceNumber": "119",
+      "detailsUrl": "https://spdx.org/licenses/NGPL.json",
+      "referenceNumber": 64,
+      "name": "Nethack General Public License",
+      "licenseId": "NGPL",
+      "seeAlso": [
+        "https://opensource.org/licenses/NGPL"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/ngrep.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ngrep.json",
+      "referenceNumber": 16,
+      "name": "ngrep License",
+      "licenseId": "ngrep",
+      "seeAlso": [
+        "https://github.com/jpr5/ngrep/blob/master/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/NICTA-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NICTA-1.0.json",
+      "referenceNumber": 406,
+      "name": "NICTA Public Software License, Version 1.0",
+      "licenseId": "NICTA-1.0",
+      "seeAlso": [
+        "https://opensource.apple.com/source/mDNSResponder/mDNSResponder-320.10/mDNSPosix/nss_ReadMe.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/NIST-PD.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NIST-PD.json",
+      "referenceNumber": 98,
+      "name": "NIST Public Domain Notice",
+      "licenseId": "NIST-PD",
+      "seeAlso": [
+        "https://github.com/tcheneau/simpleRPL/blob/e645e69e38dd4e3ccfeceb2db8cba05b7c2e0cd3/LICENSE.txt",
+        "https://github.com/tcheneau/Routing/blob/f09f46fcfe636107f22f2c98348188a65a135d98/README.md"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/NIST-PD-fallback.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NIST-PD-fallback.json",
+      "referenceNumber": 616,
+      "name": "NIST Public Domain Notice with license fallback",
+      "licenseId": "NIST-PD-fallback",
+      "seeAlso": [
+        "https://github.com/usnistgov/jsip/blob/59700e6926cbe96c5cdae897d9a7d2656b42abe3/LICENSE",
+        "https://github.com/usnistgov/fipy/blob/86aaa5c2ba2c6f1be19593c5986071cf6568cc34/LICENSE.rst"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/NIST-Software.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NIST-Software.json",
+      "referenceNumber": 447,
+      "name": "NIST Software License",
+      "licenseId": "NIST-Software",
+      "seeAlso": [
+        "https://github.com/open-quantum-safe/liboqs/blob/40b01fdbb270f8614fde30e65d30e9da18c02393/src/common/rand/rand_nist.c#L1-L15"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/NLOD-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NLOD-1.0.json",
+      "referenceNumber": 249,
+      "name": "Norwegian Licence for Open Government Data (NLOD) 1.0",
+      "licenseId": "NLOD-1.0",
+      "seeAlso": [
+        "http://data.norge.no/nlod/en/1.0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/NLOD-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NLOD-2.0.json",
+      "referenceNumber": 687,
+      "name": "Norwegian Licence for Open Government Data (NLOD) 2.0",
+      "licenseId": "NLOD-2.0",
+      "seeAlso": [
+        "http://data.norge.no/nlod/en/2.0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/NLPL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NLPL.json",
+      "referenceNumber": 161,
+      "name": "No Limit Public License",
+      "licenseId": "NLPL",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/NLPL"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Nokia.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Nokia.json",
+      "referenceNumber": 464,
       "name": "Nokia Open Source License",
       "licenseId": "Nokia",
       "seeAlso": [
         "https://opensource.org/licenses/nokia"
       ],
-      "isOsiApproved": true
+      "isOsiApproved": true,
+      "isFsfLibre": true
     },
     {
-      "reference": "./Noweb.html",
+      "reference": "https://spdx.org/licenses/NOSL.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Noweb.json",
-      "referenceNumber": "66",
+      "detailsUrl": "https://spdx.org/licenses/NOSL.json",
+      "referenceNumber": 471,
+      "name": "Netizen Open Source License",
+      "licenseId": "NOSL",
+      "seeAlso": [
+        "http://bits.netizen.com.au/licenses/NOSL/nosl.txt"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Noweb.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Noweb.json",
+      "referenceNumber": 77,
       "name": "Noweb License",
       "licenseId": "Noweb",
       "seeAlso": [
@@ -3265,23 +6158,135 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./Nunit.html",
+      "reference": "https://spdx.org/licenses/NPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NPL-1.0.json",
+      "referenceNumber": 372,
+      "name": "Netscape Public License v1.0",
+      "licenseId": "NPL-1.0",
+      "seeAlso": [
+        "http://www.mozilla.org/MPL/NPL/1.0/"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/NPL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NPL-1.1.json",
+      "referenceNumber": 518,
+      "name": "Netscape Public License v1.1",
+      "licenseId": "NPL-1.1",
+      "seeAlso": [
+        "http://www.mozilla.org/MPL/NPL/1.1/"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/NPOSL-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NPOSL-3.0.json",
+      "referenceNumber": 195,
+      "name": "Non-Profit Open Software License 3.0",
+      "licenseId": "NPOSL-3.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/NOSL3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/NRL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NRL.json",
+      "referenceNumber": 146,
+      "name": "NRL License",
+      "licenseId": "NRL",
+      "seeAlso": [
+        "http://web.mit.edu/network/isakmp/nrllicense.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/NTIA-PD.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NTIA-PD.json",
+      "referenceNumber": 426,
+      "name": "NTIA Public Domain Notice",
+      "licenseId": "NTIA-PD",
+      "seeAlso": [
+        "https://raw.githubusercontent.com/NTIA/itm/refs/heads/master/LICENSE.md",
+        "https://raw.githubusercontent.com/NTIA/scos-sensor/refs/heads/master/LICENSE.md"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/NTP.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NTP.json",
+      "referenceNumber": 621,
+      "name": "NTP License",
+      "licenseId": "NTP",
+      "seeAlso": [
+        "https://opensource.org/licenses/NTP"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/NTP-0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/NTP-0.json",
+      "referenceNumber": 566,
+      "name": "NTP No Attribution",
+      "licenseId": "NTP-0",
+      "seeAlso": [
+        "https://github.com/tytso/e2fsprogs/blob/master/lib/et/et_name.c"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Nunit.html",
       "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Nunit.json",
-      "referenceNumber": "82",
+      "detailsUrl": "https://spdx.org/licenses/Nunit.json",
+      "referenceNumber": 203,
       "name": "Nunit License",
       "licenseId": "Nunit",
       "seeAlso": [
         "https://fedoraproject.org/wiki/Licensing/Nunit"
       ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/O-UDA-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/O-UDA-1.0.json",
+      "referenceNumber": 485,
+      "name": "Open Use of Data Agreement v1.0",
+      "licenseId": "O-UDA-1.0",
+      "seeAlso": [
+        "https://github.com/microsoft/Open-Use-of-Data-Agreement/blob/v1.0/O-UDA-1.0.md",
+        "https://cdla.dev/open-use-of-data-agreement-v1-0/"
+      ],
       "isOsiApproved": false
     },
     {
-      "reference": "./OCCT-PL.html",
+      "reference": "https://spdx.org/licenses/OAR.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OCCT-PL.json",
-      "referenceNumber": "62",
+      "detailsUrl": "https://spdx.org/licenses/OAR.json",
+      "referenceNumber": 251,
+      "name": "OAR License",
+      "licenseId": "OAR",
+      "seeAlso": [
+        "https://sourceware.org/git/?p\u003dnewlib-cygwin.git;a\u003dblob;f\u003dnewlib/libc/string/strsignal.c;hb\u003dHEAD#l35"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OCCT-PL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OCCT-PL.json",
+      "referenceNumber": 371,
       "name": "Open CASCADE Technology Public License",
       "licenseId": "OCCT-PL",
       "seeAlso": [
@@ -3290,10 +6295,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./OCLC-2.0.html",
+      "reference": "https://spdx.org/licenses/OCLC-2.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OCLC-2.0.json",
-      "referenceNumber": "330",
+      "detailsUrl": "https://spdx.org/licenses/OCLC-2.0.json",
+      "referenceNumber": 274,
       "name": "OCLC Research Public License 2.0",
       "licenseId": "OCLC-2.0",
       "seeAlso": [
@@ -3303,10 +6308,24 @@
       "isOsiApproved": true
     },
     {
-      "reference": "./ODC-By-1.0.html",
+      "reference": "https://spdx.org/licenses/ODbL-1.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/ODC-By-1.0.json",
-      "referenceNumber": "369",
+      "detailsUrl": "https://spdx.org/licenses/ODbL-1.0.json",
+      "referenceNumber": 397,
+      "name": "Open Data Commons Open Database License v1.0",
+      "licenseId": "ODbL-1.0",
+      "seeAlso": [
+        "http://www.opendatacommons.org/licenses/odbl/1.0/",
+        "https://opendatacommons.org/licenses/odbl/1-0/"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/ODC-By-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ODC-By-1.0.json",
+      "referenceNumber": 46,
       "name": "Open Data Commons Attribution License v1.0",
       "licenseId": "ODC-By-1.0",
       "seeAlso": [
@@ -3315,39 +6334,75 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./ODbL-1.0.html",
+      "reference": "https://spdx.org/licenses/OFFIS.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/ODbL-1.0.json",
-      "referenceNumber": "329",
-      "name": "ODC Open Database License v1.0",
-      "licenseId": "ODbL-1.0",
+      "detailsUrl": "https://spdx.org/licenses/OFFIS.json",
+      "referenceNumber": 368,
+      "name": "OFFIS License",
+      "licenseId": "OFFIS",
       "seeAlso": [
-        "http://www.opendatacommons.org/licenses/odbl/1.0/"
+        "https://sourceforge.net/p/xmedcon/code/ci/master/tree/libs/dicom/README"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./OFL-1.0.html",
+      "reference": "https://spdx.org/licenses/OFL-1.0.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/OFL-1.0.json",
-      "referenceNumber": "75",
+      "detailsUrl": "https://spdx.org/licenses/OFL-1.0.json",
+      "referenceNumber": 589,
       "name": "SIL Open Font License 1.0",
       "licenseId": "OFL-1.0",
+      "seeAlso": [
+        "http://scripts.sil.org/cms/scripts/page.php?item_id\u003dOFL10_web"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/OFL-1.0-no-RFN.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OFL-1.0-no-RFN.json",
+      "referenceNumber": 653,
+      "name": "SIL Open Font License 1.0 with no Reserved Font Name",
+      "licenseId": "OFL-1.0-no-RFN",
       "seeAlso": [
         "http://scripts.sil.org/cms/scripts/page.php?item_id\u003dOFL10_web"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./OFL-1.1.html",
+      "reference": "https://spdx.org/licenses/OFL-1.0-RFN.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/OFL-1.1.json",
-      "referenceNumber": "300",
+      "detailsUrl": "https://spdx.org/licenses/OFL-1.0-RFN.json",
+      "referenceNumber": 201,
+      "name": "SIL Open Font License 1.0 with Reserved Font Name",
+      "licenseId": "OFL-1.0-RFN",
+      "seeAlso": [
+        "http://scripts.sil.org/cms/scripts/page.php?item_id\u003dOFL10_web"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OFL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OFL-1.1.json",
+      "referenceNumber": 608,
       "name": "SIL Open Font License 1.1",
       "licenseId": "OFL-1.1",
+      "seeAlso": [
+        "http://scripts.sil.org/cms/scripts/page.php?item_id\u003dOFL_web",
+        "https://opensource.org/licenses/OFL-1.1"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/OFL-1.1-no-RFN.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OFL-1.1-no-RFN.json",
+      "referenceNumber": 204,
+      "name": "SIL Open Font License 1.1 with no Reserved Font Name",
+      "licenseId": "OFL-1.1-no-RFN",
       "seeAlso": [
         "http://scripts.sil.org/cms/scripts/page.php?item_id\u003dOFL_web",
         "https://opensource.org/licenses/OFL-1.1"
@@ -3355,10 +6410,59 @@
       "isOsiApproved": true
     },
     {
-      "reference": "./OGL-UK-1.0.html",
+      "reference": "https://spdx.org/licenses/OFL-1.1-RFN.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OGL-UK-1.0.json",
-      "referenceNumber": "336",
+      "detailsUrl": "https://spdx.org/licenses/OFL-1.1-RFN.json",
+      "referenceNumber": 82,
+      "name": "SIL Open Font License 1.1 with Reserved Font Name",
+      "licenseId": "OFL-1.1-RFN",
+      "seeAlso": [
+        "http://scripts.sil.org/cms/scripts/page.php?item_id\u003dOFL_web",
+        "https://opensource.org/licenses/OFL-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/OGC-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OGC-1.0.json",
+      "referenceNumber": 612,
+      "name": "OGC Software License, Version 1.0",
+      "licenseId": "OGC-1.0",
+      "seeAlso": [
+        "https://www.ogc.org/ogc/software/1.0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OGDL-Taiwan-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OGDL-Taiwan-1.0.json",
+      "referenceNumber": 129,
+      "name": "Taiwan Open Government Data License, version 1.0",
+      "licenseId": "OGDL-Taiwan-1.0",
+      "seeAlso": [
+        "https://data.gov.tw/license"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OGL-Canada-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OGL-Canada-2.0.json",
+      "referenceNumber": 544,
+      "name": "Open Government Licence - Canada",
+      "licenseId": "OGL-Canada-2.0",
+      "seeAlso": [
+        "https://open.canada.ca/en/open-government-licence-canada"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OGL-UK-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OGL-UK-1.0.json",
+      "referenceNumber": 168,
       "name": "Open Government Licence v1.0",
       "licenseId": "OGL-UK-1.0",
       "seeAlso": [
@@ -3367,10 +6471,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./OGL-UK-2.0.html",
+      "reference": "https://spdx.org/licenses/OGL-UK-2.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OGL-UK-2.0.json",
-      "referenceNumber": "13",
+      "detailsUrl": "https://spdx.org/licenses/OGL-UK-2.0.json",
+      "referenceNumber": 400,
       "name": "Open Government Licence v2.0",
       "licenseId": "OGL-UK-2.0",
       "seeAlso": [
@@ -3379,10 +6483,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./OGL-UK-3.0.html",
+      "reference": "https://spdx.org/licenses/OGL-UK-3.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OGL-UK-3.0.json",
-      "referenceNumber": "20",
+      "detailsUrl": "https://spdx.org/licenses/OGL-UK-3.0.json",
+      "referenceNumber": 570,
       "name": "Open Government Licence v3.0",
       "licenseId": "OGL-UK-3.0",
       "seeAlso": [
@@ -3391,10 +6495,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./OGTSL.html",
+      "reference": "https://spdx.org/licenses/OGTSL.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OGTSL.json",
-      "referenceNumber": "24",
+      "detailsUrl": "https://spdx.org/licenses/OGTSL.json",
+      "referenceNumber": 534,
       "name": "Open Group Test Suite License",
       "licenseId": "OGTSL",
       "seeAlso": [
@@ -3404,10 +6508,10 @@
       "isOsiApproved": true
     },
     {
-      "reference": "./OLDAP-1.1.html",
+      "reference": "https://spdx.org/licenses/OLDAP-1.1.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-1.1.json",
-      "referenceNumber": "52",
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-1.1.json",
+      "referenceNumber": 333,
       "name": "Open LDAP Public License v1.1",
       "licenseId": "OLDAP-1.1",
       "seeAlso": [
@@ -3416,10 +6520,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./OLDAP-1.2.html",
+      "reference": "https://spdx.org/licenses/OLDAP-1.2.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-1.2.json",
-      "referenceNumber": "45",
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-1.2.json",
+      "referenceNumber": 281,
       "name": "Open LDAP Public License v1.2",
       "licenseId": "OLDAP-1.2",
       "seeAlso": [
@@ -3428,10 +6532,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./OLDAP-1.3.html",
+      "reference": "https://spdx.org/licenses/OLDAP-1.3.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-1.3.json",
-      "referenceNumber": "40",
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-1.3.json",
+      "referenceNumber": 386,
       "name": "Open LDAP Public License v1.3",
       "licenseId": "OLDAP-1.3",
       "seeAlso": [
@@ -3440,10 +6544,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./OLDAP-1.4.html",
+      "reference": "https://spdx.org/licenses/OLDAP-1.4.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-1.4.json",
-      "referenceNumber": "47",
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-1.4.json",
+      "referenceNumber": 105,
       "name": "Open LDAP Public License v1.4",
       "licenseId": "OLDAP-1.4",
       "seeAlso": [
@@ -3452,10 +6556,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./OLDAP-2.0.html",
+      "reference": "https://spdx.org/licenses/OLDAP-2.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.0.json",
-      "referenceNumber": "23",
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.0.json",
+      "referenceNumber": 657,
       "name": "Open LDAP Public License v2.0 (or possibly 2.0A and 2.0B)",
       "licenseId": "OLDAP-2.0",
       "seeAlso": [
@@ -3464,10 +6568,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./OLDAP-2.0.1.html",
+      "reference": "https://spdx.org/licenses/OLDAP-2.0.1.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.0.1.json",
-      "referenceNumber": "270",
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.0.1.json",
+      "referenceNumber": 654,
       "name": "Open LDAP Public License v2.0.1",
       "licenseId": "OLDAP-2.0.1",
       "seeAlso": [
@@ -3476,10 +6580,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./OLDAP-2.1.html",
+      "reference": "https://spdx.org/licenses/OLDAP-2.1.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.1.json",
-      "referenceNumber": "388",
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.1.json",
+      "referenceNumber": 170,
       "name": "Open LDAP Public License v2.1",
       "licenseId": "OLDAP-2.1",
       "seeAlso": [
@@ -3488,10 +6592,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./OLDAP-2.2.html",
+      "reference": "https://spdx.org/licenses/OLDAP-2.2.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.2.json",
-      "referenceNumber": "307",
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.2.json",
+      "referenceNumber": 667,
       "name": "Open LDAP Public License v2.2",
       "licenseId": "OLDAP-2.2",
       "seeAlso": [
@@ -3500,10 +6604,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./OLDAP-2.2.1.html",
+      "reference": "https://spdx.org/licenses/OLDAP-2.2.1.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.2.1.json",
-      "referenceNumber": "372",
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.2.1.json",
+      "referenceNumber": 378,
       "name": "Open LDAP Public License v2.2.1",
       "licenseId": "OLDAP-2.2.1",
       "seeAlso": [
@@ -3512,10 +6616,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./OLDAP-2.2.2.html",
+      "reference": "https://spdx.org/licenses/OLDAP-2.2.2.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.2.2.json",
-      "referenceNumber": "164",
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.2.2.json",
+      "referenceNumber": 314,
       "name": "Open LDAP Public License 2.2.2",
       "licenseId": "OLDAP-2.2.2",
       "seeAlso": [
@@ -3524,23 +6628,23 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./OLDAP-2.3.html",
+      "reference": "https://spdx.org/licenses/OLDAP-2.3.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.3.json",
-      "referenceNumber": "222",
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.3.json",
+      "referenceNumber": 411,
       "name": "Open LDAP Public License v2.3",
       "licenseId": "OLDAP-2.3",
       "seeAlso": [
         "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003dd32cf54a32d581ab475d23c810b0a7fbaf8d63c3"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": false,
+      "isFsfLibre": true
     },
     {
-      "reference": "./OLDAP-2.4.html",
+      "reference": "https://spdx.org/licenses/OLDAP-2.4.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.4.json",
-      "referenceNumber": "109",
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.4.json",
+      "referenceNumber": 382,
       "name": "Open LDAP Public License v2.4",
       "licenseId": "OLDAP-2.4",
       "seeAlso": [
@@ -3549,10 +6653,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./OLDAP-2.5.html",
+      "reference": "https://spdx.org/licenses/OLDAP-2.5.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.5.json",
-      "referenceNumber": "102",
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.5.json",
+      "referenceNumber": 443,
       "name": "Open LDAP Public License v2.5",
       "licenseId": "OLDAP-2.5",
       "seeAlso": [
@@ -3561,10 +6665,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./OLDAP-2.6.html",
+      "reference": "https://spdx.org/licenses/OLDAP-2.6.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.6.json",
-      "referenceNumber": "103",
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.6.json",
+      "referenceNumber": 344,
       "name": "Open LDAP Public License v2.6",
       "licenseId": "OLDAP-2.6",
       "seeAlso": [
@@ -3573,35 +6677,48 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./OLDAP-2.7.html",
+      "reference": "https://spdx.org/licenses/OLDAP-2.7.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.7.json",
-      "referenceNumber": "221",
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.7.json",
+      "referenceNumber": 574,
       "name": "Open LDAP Public License v2.7",
       "licenseId": "OLDAP-2.7",
       "seeAlso": [
         "http://www.openldap.org/devel/gitweb.cgi?p\u003dopenldap.git;a\u003dblob;f\u003dLICENSE;hb\u003d47c2415c1df81556eeb39be6cad458ef87c534a2"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": false,
+      "isFsfLibre": true
     },
     {
-      "reference": "./OLDAP-2.8.html",
+      "reference": "https://spdx.org/licenses/OLDAP-2.8.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.8.json",
-      "referenceNumber": "243",
+      "detailsUrl": "https://spdx.org/licenses/OLDAP-2.8.json",
+      "referenceNumber": 364,
       "name": "Open LDAP Public License v2.8",
       "licenseId": "OLDAP-2.8",
       "seeAlso": [
         "http://www.openldap.org/software/release/license.html"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": true
     },
     {
-      "reference": "./OML.html",
+      "reference": "https://spdx.org/licenses/OLFL-1.3.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OML.json",
-      "referenceNumber": "165",
+      "detailsUrl": "https://spdx.org/licenses/OLFL-1.3.json",
+      "referenceNumber": 121,
+      "name": "Open Logistics Foundation License Version 1.3",
+      "licenseId": "OLFL-1.3",
+      "seeAlso": [
+        "https://openlogisticsfoundation.org/licenses/",
+        "https://opensource.org/license/olfl-1-3/"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/OML.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OML.json",
+      "referenceNumber": 116,
       "name": "Open Market License",
       "licenseId": "OML",
       "seeAlso": [
@@ -3610,23 +6727,103 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./OPL-1.0.html",
+      "reference": "https://spdx.org/licenses/OpenPBS-2.3.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OPL-1.0.json",
-      "referenceNumber": "327",
+      "detailsUrl": "https://spdx.org/licenses/OpenPBS-2.3.json",
+      "referenceNumber": 2,
+      "name": "OpenPBS v2.3 Software License",
+      "licenseId": "OpenPBS-2.3",
+      "seeAlso": [
+        "https://github.com/adaptivecomputing/torque/blob/master/PBS_License.txt",
+        "https://www.mcs.anl.gov/research/projects/openpbs/PBS_License.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OpenSSL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OpenSSL.json",
+      "referenceNumber": 275,
+      "name": "OpenSSL License",
+      "licenseId": "OpenSSL",
+      "seeAlso": [
+        "http://www.openssl.org/source/license.html"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/OpenSSL-standalone.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OpenSSL-standalone.json",
+      "referenceNumber": 128,
+      "name": "OpenSSL License - standalone",
+      "licenseId": "OpenSSL-standalone",
+      "seeAlso": [
+        "https://library.netapp.com/ecm/ecm_download_file/ECMP1196395",
+        "https://hstechdocs.helpsystems.com/manuals/globalscape/archive/cuteftp6/open_ssl_license_agreement.htm"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OpenVision.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OpenVision.json",
+      "referenceNumber": 36,
+      "name": "OpenVision License",
+      "licenseId": "OpenVision",
+      "seeAlso": [
+        "https://github.com/krb5/krb5/blob/krb5-1.21.2-final/NOTICE#L66-L98",
+        "https://web.mit.edu/kerberos/krb5-1.21/doc/mitK5license.html",
+        "https://fedoraproject.org/wiki/Licensing:MIT#OpenVision_Variant"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OPL-1.0.json",
+      "referenceNumber": 614,
       "name": "Open Public License v1.0",
       "licenseId": "OPL-1.0",
       "seeAlso": [
         "http://old.koalateam.com/jackaroo/OPL_1_0.TXT",
         "https://fedoraproject.org/wiki/Licensing/Open_Public_License"
       ],
+      "isOsiApproved": false,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OPL-UK-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OPL-UK-3.0.json",
+      "referenceNumber": 285,
+      "name": "United    Kingdom Open Parliament Licence v3.0",
+      "licenseId": "OPL-UK-3.0",
+      "seeAlso": [
+        "https://www.parliament.uk/site-information/copyright-parliament/open-parliament-licence/"
+      ],
       "isOsiApproved": false
     },
     {
-      "reference": "./OSET-PL-2.1.html",
+      "reference": "https://spdx.org/licenses/OPUBL-1.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OSET-PL-2.1.json",
-      "referenceNumber": "195",
+      "detailsUrl": "https://spdx.org/licenses/OPUBL-1.0.json",
+      "referenceNumber": 414,
+      "name": "Open Publication License v1.0",
+      "licenseId": "OPUBL-1.0",
+      "seeAlso": [
+        "http://opencontent.org/openpub/",
+        "https://www.debian.org/opl",
+        "https://www.ctan.org/license/opl"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/OSET-PL-2.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/OSET-PL-2.1.json",
+      "referenceNumber": 183,
       "name": "OSET Public License version 2.1",
       "licenseId": "OSET-PL-2.1",
       "seeAlso": [
@@ -3636,102 +6833,126 @@
       "isOsiApproved": true
     },
     {
-      "reference": "./OSL-1.0.html",
+      "reference": "https://spdx.org/licenses/OSL-1.0.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/OSL-1.0.json",
-      "referenceNumber": "89",
+      "detailsUrl": "https://spdx.org/licenses/OSL-1.0.json",
+      "referenceNumber": 651,
       "name": "Open Software License 1.0",
       "licenseId": "OSL-1.0",
       "seeAlso": [
         "https://opensource.org/licenses/OSL-1.0"
       ],
-      "isOsiApproved": true
+      "isOsiApproved": true,
+      "isFsfLibre": true
     },
     {
-      "reference": "./OSL-1.1.html",
+      "reference": "https://spdx.org/licenses/OSL-1.1.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/OSL-1.1.json",
-      "referenceNumber": "172",
+      "detailsUrl": "https://spdx.org/licenses/OSL-1.1.json",
+      "referenceNumber": 453,
       "name": "Open Software License 1.1",
       "licenseId": "OSL-1.1",
       "seeAlso": [
         "https://fedoraproject.org/wiki/Licensing/OSL1.1"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": false,
+      "isFsfLibre": true
     },
     {
-      "reference": "./OSL-2.0.html",
+      "reference": "https://spdx.org/licenses/OSL-2.0.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/OSL-2.0.json",
-      "referenceNumber": "352",
+      "detailsUrl": "https://spdx.org/licenses/OSL-2.0.json",
+      "referenceNumber": 179,
       "name": "Open Software License 2.0",
       "licenseId": "OSL-2.0",
       "seeAlso": [
         "http://web.archive.org/web/20041020171434/http://www.rosenlaw.com/osl2.0.html"
       ],
-      "isOsiApproved": true
+      "isOsiApproved": true,
+      "isFsfLibre": true
     },
     {
-      "reference": "./OSL-2.1.html",
+      "reference": "https://spdx.org/licenses/OSL-2.1.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/OSL-2.1.json",
-      "referenceNumber": "151",
+      "detailsUrl": "https://spdx.org/licenses/OSL-2.1.json",
+      "referenceNumber": 29,
       "name": "Open Software License 2.1",
       "licenseId": "OSL-2.1",
       "seeAlso": [
         "http://web.archive.org/web/20050212003940/http://www.rosenlaw.com/osl21.htm",
         "https://opensource.org/licenses/OSL-2.1"
       ],
-      "isOsiApproved": true
+      "isOsiApproved": true,
+      "isFsfLibre": true
     },
     {
-      "reference": "./OSL-3.0.html",
+      "reference": "https://spdx.org/licenses/OSL-3.0.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/OSL-3.0.json",
-      "referenceNumber": "143",
+      "detailsUrl": "https://spdx.org/licenses/OSL-3.0.json",
+      "referenceNumber": 3,
       "name": "Open Software License 3.0",
       "licenseId": "OSL-3.0",
       "seeAlso": [
         "https://web.archive.org/web/20120101081418/http://rosenlaw.com:80/OSL3.0.htm",
         "https://opensource.org/licenses/OSL-3.0"
       ],
-      "isOsiApproved": true
+      "isOsiApproved": true,
+      "isFsfLibre": true
     },
     {
-      "reference": "./OpenSSL.html",
+      "reference": "https://spdx.org/licenses/PADL.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/OpenSSL.json",
-      "referenceNumber": "78",
-      "name": "OpenSSL License",
-      "licenseId": "OpenSSL",
+      "detailsUrl": "https://spdx.org/licenses/PADL.json",
+      "referenceNumber": 284,
+      "name": "PADL License",
+      "licenseId": "PADL",
       "seeAlso": [
-        "http://www.openssl.org/source/license.html"
+        "https://git.openldap.org/openldap/openldap/-/blob/master/libraries/libldap/os-local.c?ref_type\u003dheads#L19-23"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./PDDL-1.0.html",
+      "reference": "https://spdx.org/licenses/Parity-6.0.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/PDDL-1.0.json",
-      "referenceNumber": "126",
-      "name": "ODC Public Domain Dedication \u0026 License 1.0",
+      "detailsUrl": "https://spdx.org/licenses/Parity-6.0.0.json",
+      "referenceNumber": 241,
+      "name": "The Parity Public License 6.0.0",
+      "licenseId": "Parity-6.0.0",
+      "seeAlso": [
+        "https://paritylicense.com/versions/6.0.0.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Parity-7.0.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Parity-7.0.0.json",
+      "referenceNumber": 235,
+      "name": "The Parity Public License 7.0.0",
+      "licenseId": "Parity-7.0.0",
+      "seeAlso": [
+        "https://paritylicense.com/versions/7.0.0.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/PDDL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/PDDL-1.0.json",
+      "referenceNumber": 684,
+      "name": "Open Data Commons Public Domain Dedication \u0026 License 1.0",
       "licenseId": "PDDL-1.0",
       "seeAlso": [
-        "http://opendatacommons.org/licenses/pddl/1.0/"
+        "http://opendatacommons.org/licenses/pddl/1.0/",
+        "https://opendatacommons.org/licenses/pddl/"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./PHP-3.0.html",
+      "reference": "https://spdx.org/licenses/PHP-3.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/PHP-3.0.json",
-      "referenceNumber": "184",
+      "detailsUrl": "https://spdx.org/licenses/PHP-3.0.json",
+      "referenceNumber": 133,
       "name": "PHP License v3.0",
       "licenseId": "PHP-3.0",
       "seeAlso": [
@@ -3741,35 +6962,49 @@
       "isOsiApproved": true
     },
     {
-      "reference": "./PHP-3.01.html",
+      "reference": "https://spdx.org/licenses/PHP-3.01.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/PHP-3.01.json",
-      "referenceNumber": "3",
+      "detailsUrl": "https://spdx.org/licenses/PHP-3.01.json",
+      "referenceNumber": 221,
       "name": "PHP License v3.01",
       "licenseId": "PHP-3.01",
       "seeAlso": [
         "http://www.php.net/license/3_01.txt"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": true,
+      "isFsfLibre": true
     },
     {
-      "reference": "./Parity-6.0.0.html",
+      "reference": "https://spdx.org/licenses/Pixar.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Parity-6.0.0.json",
-      "referenceNumber": "394",
-      "name": "The Parity Public License 6.0.0",
-      "licenseId": "Parity-6.0.0",
+      "detailsUrl": "https://spdx.org/licenses/Pixar.json",
+      "referenceNumber": 435,
+      "name": "Pixar License",
+      "licenseId": "Pixar",
       "seeAlso": [
-        "https://paritylicense.com/versions/6.0.0.html"
+        "https://github.com/PixarAnimationStudios/OpenSubdiv/raw/v3_5_0/LICENSE.txt",
+        "https://graphics.pixar.com/opensubdiv/docs/license.html",
+        "https://github.com/PixarAnimationStudios/OpenSubdiv/blob/v3_5_0/opensubdiv/version.cpp#L2-L22"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./Plexus.html",
+      "reference": "https://spdx.org/licenses/pkgconf.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Plexus.json",
-      "referenceNumber": "150",
+      "detailsUrl": "https://spdx.org/licenses/pkgconf.json",
+      "referenceNumber": 670,
+      "name": "pkgconf License",
+      "licenseId": "pkgconf",
+      "seeAlso": [
+        "https://github.com/pkgconf/pkgconf/blob/master/cli/main.c#L8"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Plexus.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Plexus.json",
+      "referenceNumber": 181,
       "name": "Plexus Classworlds License",
       "licenseId": "Plexus",
       "seeAlso": [
@@ -3778,10 +7013,46 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./PostgreSQL.html",
+      "reference": "https://spdx.org/licenses/pnmstitch.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/PostgreSQL.json",
-      "referenceNumber": "11",
+      "detailsUrl": "https://spdx.org/licenses/pnmstitch.json",
+      "referenceNumber": 691,
+      "name": "pnmstitch License",
+      "licenseId": "pnmstitch",
+      "seeAlso": [
+        "https://sourceforge.net/p/netpbm/code/HEAD/tree/super_stable/editor/pnmstitch.c#l2"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/PolyForm-Noncommercial-1.0.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/PolyForm-Noncommercial-1.0.0.json",
+      "referenceNumber": 119,
+      "name": "PolyForm Noncommercial License 1.0.0",
+      "licenseId": "PolyForm-Noncommercial-1.0.0",
+      "seeAlso": [
+        "https://polyformproject.org/licenses/noncommercial/1.0.0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/PolyForm-Small-Business-1.0.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/PolyForm-Small-Business-1.0.0.json",
+      "referenceNumber": 30,
+      "name": "PolyForm Small Business License 1.0.0",
+      "licenseId": "PolyForm-Small-Business-1.0.0",
+      "seeAlso": [
+        "https://polyformproject.org/licenses/small-business/1.0.0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/PostgreSQL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/PostgreSQL.json",
+      "referenceNumber": 697,
       "name": "PostgreSQL License",
       "licenseId": "PostgreSQL",
       "seeAlso": [
@@ -3791,37 +7062,100 @@
       "isOsiApproved": true
     },
     {
-      "reference": "./Python-2.0.html",
+      "reference": "https://spdx.org/licenses/PPL.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Python-2.0.json",
-      "referenceNumber": "381",
+      "detailsUrl": "https://spdx.org/licenses/PPL.json",
+      "referenceNumber": 150,
+      "name": "Peer Production License",
+      "licenseId": "PPL",
+      "seeAlso": [
+        "https://wiki.p2pfoundation.net/Peer_Production_License",
+        "http://www.networkcultures.org/_uploads/%233notebook_telekommunist.pdf"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/PSF-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/PSF-2.0.json",
+      "referenceNumber": 211,
+      "name": "Python Software Foundation License 2.0",
+      "licenseId": "PSF-2.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/Python-2.0",
+        "https://matplotlib.org/stable/project/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/psfrag.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/psfrag.json",
+      "referenceNumber": 423,
+      "name": "psfrag License",
+      "licenseId": "psfrag",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/psfrag"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/psutils.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/psutils.json",
+      "referenceNumber": 500,
+      "name": "psutils License",
+      "licenseId": "psutils",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/psutils"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Python-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Python-2.0.json",
+      "referenceNumber": 628,
       "name": "Python License 2.0",
       "licenseId": "Python-2.0",
       "seeAlso": [
         "https://opensource.org/licenses/Python-2.0"
       ],
-      "isOsiApproved": true
+      "isOsiApproved": true,
+      "isFsfLibre": true
     },
     {
-      "reference": "./QPL-1.0.html",
+      "reference": "https://spdx.org/licenses/Python-2.0.1.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/QPL-1.0.json",
-      "referenceNumber": "279",
-      "name": "Q Public License 1.0",
-      "licenseId": "QPL-1.0",
+      "detailsUrl": "https://spdx.org/licenses/Python-2.0.1.json",
+      "referenceNumber": 586,
+      "name": "Python License 2.0.1",
+      "licenseId": "Python-2.0.1",
       "seeAlso": [
-        "http://doc.qt.nokia.com/3.3/license.html",
-        "https://opensource.org/licenses/QPL-1.0"
+        "https://www.python.org/download/releases/2.0.1/license/",
+        "https://docs.python.org/3/license.html",
+        "https://github.com/python/cpython/blob/main/LICENSE"
       ],
-      "isOsiApproved": true
+      "isOsiApproved": false
     },
     {
-      "reference": "./Qhull.html",
+      "reference": "https://spdx.org/licenses/python-ldap.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Qhull.json",
-      "referenceNumber": "118",
+      "detailsUrl": "https://spdx.org/licenses/python-ldap.json",
+      "referenceNumber": 630,
+      "name": "Python ldap License",
+      "licenseId": "python-ldap",
+      "seeAlso": [
+        "https://github.com/python-ldap/python-ldap/blob/main/LICENCE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Qhull.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Qhull.json",
+      "referenceNumber": 590,
       "name": "Qhull License",
       "licenseId": "Qhull",
       "seeAlso": [
@@ -3830,22 +7164,74 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./RHeCos-1.1.html",
+      "reference": "https://spdx.org/licenses/QPL-1.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/RHeCos-1.1.json",
-      "referenceNumber": "58",
+      "detailsUrl": "https://spdx.org/licenses/QPL-1.0.json",
+      "referenceNumber": 693,
+      "name": "Q Public License 1.0",
+      "licenseId": "QPL-1.0",
+      "seeAlso": [
+        "http://doc.qt.nokia.com/3.3/license.html",
+        "https://opensource.org/licenses/QPL-1.0",
+        "https://doc.qt.io/archives/3.3/license.html"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/QPL-1.0-INRIA-2004.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/QPL-1.0-INRIA-2004.json",
+      "referenceNumber": 117,
+      "name": "Q Public License 1.0 - INRIA 2004 variant",
+      "licenseId": "QPL-1.0-INRIA-2004",
+      "seeAlso": [
+        "https://github.com/maranget/hevea/blob/master/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/radvd.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/radvd.json",
+      "referenceNumber": 678,
+      "name": "radvd License",
+      "licenseId": "radvd",
+      "seeAlso": [
+        "https://github.com/radvd-project/radvd/blob/master/COPYRIGHT"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Rdisc.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Rdisc.json",
+      "referenceNumber": 4,
+      "name": "Rdisc License",
+      "licenseId": "Rdisc",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Rdisc_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/RHeCos-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/RHeCos-1.1.json",
+      "referenceNumber": 258,
       "name": "Red Hat eCos Public License v1.1",
       "licenseId": "RHeCos-1.1",
       "seeAlso": [
         "http://ecos.sourceware.org/old-license.html"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": false,
+      "isFsfLibre": false
     },
     {
-      "reference": "./RPL-1.1.html",
+      "reference": "https://spdx.org/licenses/RPL-1.1.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/RPL-1.1.json",
-      "referenceNumber": "208",
+      "detailsUrl": "https://spdx.org/licenses/RPL-1.1.json",
+      "referenceNumber": 57,
       "name": "Reciprocal Public License 1.1",
       "licenseId": "RPL-1.1",
       "seeAlso": [
@@ -3854,10 +7240,10 @@
       "isOsiApproved": true
     },
     {
-      "reference": "./RPL-1.5.html",
+      "reference": "https://spdx.org/licenses/RPL-1.5.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/RPL-1.5.json",
-      "referenceNumber": "99",
+      "detailsUrl": "https://spdx.org/licenses/RPL-1.5.json",
+      "referenceNumber": 413,
       "name": "Reciprocal Public License 1.5",
       "licenseId": "RPL-1.5",
       "seeAlso": [
@@ -3866,25 +7252,25 @@
       "isOsiApproved": true
     },
     {
-      "reference": "./RPSL-1.0.html",
+      "reference": "https://spdx.org/licenses/RPSL-1.0.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/RPSL-1.0.json",
-      "referenceNumber": "50",
+      "detailsUrl": "https://spdx.org/licenses/RPSL-1.0.json",
+      "referenceNumber": 104,
       "name": "RealNetworks Public Source License v1.0",
       "licenseId": "RPSL-1.0",
       "seeAlso": [
         "https://helixcommunity.org/content/rpsl",
         "https://opensource.org/licenses/RPSL-1.0"
       ],
-      "isOsiApproved": true
+      "isOsiApproved": true,
+      "isFsfLibre": true
     },
     {
-      "reference": "./RSA-MD.html",
+      "reference": "https://spdx.org/licenses/RSA-MD.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/RSA-MD.json",
-      "referenceNumber": "269",
-      "name": "RSA Message-Digest License ",
+      "detailsUrl": "https://spdx.org/licenses/RSA-MD.json",
+      "referenceNumber": 12,
+      "name": "RSA Message-Digest License",
       "licenseId": "RSA-MD",
       "seeAlso": [
         "http://www.faqs.org/rfcs/rfc1321.html"
@@ -3892,10 +7278,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./RSCPL.html",
+      "reference": "https://spdx.org/licenses/RSCPL.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/RSCPL.json",
-      "referenceNumber": "328",
+      "detailsUrl": "https://spdx.org/licenses/RSCPL.json",
+      "referenceNumber": 166,
       "name": "Ricoh Source Code Public License",
       "licenseId": "RSCPL",
       "seeAlso": [
@@ -3905,35 +7291,37 @@
       "isOsiApproved": true
     },
     {
-      "reference": "./Rdisc.html",
+      "reference": "https://spdx.org/licenses/Ruby.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Rdisc.json",
-      "referenceNumber": "311",
-      "name": "Rdisc License",
-      "licenseId": "Rdisc",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Rdisc_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Ruby.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Ruby.json",
-      "referenceNumber": "14",
+      "detailsUrl": "https://spdx.org/licenses/Ruby.json",
+      "referenceNumber": 490,
       "name": "Ruby License",
       "licenseId": "Ruby",
       "seeAlso": [
-        "http://www.ruby-lang.org/en/LICENSE.txt"
+        "https://www.ruby-lang.org/en/about/license.txt"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Ruby-pty.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Ruby-pty.json",
+      "referenceNumber": 509,
+      "name": "Ruby pty extension license",
+      "licenseId": "Ruby-pty",
+      "seeAlso": [
+        "https://github.com/ruby/ruby/blob/9f6deaa6888a423720b4b127b5314f0ad26cc2e6/ext/pty/pty.c#L775-L786",
+        "https://github.com/ruby/ruby/commit/0a64817fb80016030c03518fb9459f63c11605ea#diff-ef5fa30838d6d0cecad9e675cc50b24628cfe2cb277c346053fafcc36c91c204",
+        "https://github.com/ruby/ruby/commit/0a64817fb80016030c03518fb9459f63c11605ea#diff-fedf217c1ce44bda01f0a678d3ff8b198bed478754d699c527a698ad933979a0"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./SAX-PD.html",
+      "reference": "https://spdx.org/licenses/SAX-PD.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/SAX-PD.json",
-      "referenceNumber": "146",
+      "detailsUrl": "https://spdx.org/licenses/SAX-PD.json",
+      "referenceNumber": 22,
       "name": "Sax Public Domain Notice",
       "licenseId": "SAX-PD",
       "seeAlso": [
@@ -3942,183 +7330,22 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./SCEA.html",
+      "reference": "https://spdx.org/licenses/SAX-PD-2.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/SCEA.json",
-      "referenceNumber": "131",
-      "name": "SCEA Shared Source License",
-      "licenseId": "SCEA",
+      "detailsUrl": "https://spdx.org/licenses/SAX-PD-2.0.json",
+      "referenceNumber": 346,
+      "name": "Sax Public Domain Notice 2.0",
+      "licenseId": "SAX-PD-2.0",
       "seeAlso": [
-        "http://research.scea.com/scea_shared_source_license.html"
+        "http://www.saxproject.org/copying.html"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./SGI-B-1.0.html",
+      "reference": "https://spdx.org/licenses/Saxpath.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/SGI-B-1.0.json",
-      "referenceNumber": "182",
-      "name": "SGI Free Software License B v1.0",
-      "licenseId": "SGI-B-1.0",
-      "seeAlso": [
-        "http://oss.sgi.com/projects/FreeB/SGIFreeSWLicB.1.0.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./SGI-B-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/SGI-B-1.1.json",
-      "referenceNumber": "278",
-      "name": "SGI Free Software License B v1.1",
-      "licenseId": "SGI-B-1.1",
-      "seeAlso": [
-        "http://oss.sgi.com/projects/FreeB/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./SGI-B-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/SGI-B-2.0.json",
-      "referenceNumber": "29",
-      "name": "SGI Free Software License B v2.0",
-      "licenseId": "SGI-B-2.0",
-      "seeAlso": [
-        "http://oss.sgi.com/projects/FreeB/SGIFreeSWLicB.2.0.pdf"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./SHL-0.5.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/SHL-0.5.json",
-      "referenceNumber": "46",
-      "name": "Solderpad Hardware License v0.5",
-      "licenseId": "SHL-0.5",
-      "seeAlso": [
-        "https://solderpad.org/licenses/SHL-0.5/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./SHL-0.51.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/SHL-0.51.json",
-      "referenceNumber": "271",
-      "name": "Solderpad Hardware License, Version 0.51",
-      "licenseId": "SHL-0.51",
-      "seeAlso": [
-        "https://solderpad.org/licenses/SHL-0.51/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./SISSL.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/SISSL.json",
-      "referenceNumber": "73",
-      "name": "Sun Industry Standards Source License v1.1",
-      "licenseId": "SISSL",
-      "seeAlso": [
-        "http://www.openoffice.org/licenses/sissl_license.html",
-        "https://opensource.org/licenses/SISSL"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./SISSL-1.2.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/SISSL-1.2.json",
-      "referenceNumber": "59",
-      "name": "Sun Industry Standards Source License v1.2",
-      "licenseId": "SISSL-1.2",
-      "seeAlso": [
-        "http://gridscheduler.sourceforge.net/Gridengine_SISSL_license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./SMLNJ.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/SMLNJ.json",
-      "referenceNumber": "210",
-      "name": "Standard ML of New Jersey License",
-      "licenseId": "SMLNJ",
-      "seeAlso": [
-        "https://www.smlnj.org/license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./SMPPL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/SMPPL.json",
-      "referenceNumber": "100",
-      "name": "Secure Messaging Protocol Public License",
-      "licenseId": "SMPPL",
-      "seeAlso": [
-        "https://github.com/dcblake/SMP/blob/master/Documentation/License.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./SNIA.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/SNIA.json",
-      "referenceNumber": "291",
-      "name": "SNIA Public License 1.1",
-      "licenseId": "SNIA",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/SNIA_Public_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./SPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/SPL-1.0.json",
-      "referenceNumber": "238",
-      "name": "Sun Public License v1.0",
-      "licenseId": "SPL-1.0",
-      "seeAlso": [
-        "https://opensource.org/licenses/SPL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./SSPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/SSPL-1.0.json",
-      "referenceNumber": "323",
-      "name": "Server Side Public License, v 1",
-      "licenseId": "SSPL-1.0",
-      "seeAlso": [
-        "https://www.mongodb.com/licensing/server-side-public-license"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./SWL.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/SWL.json",
-      "referenceNumber": "87",
-      "name": "Scheme Widget Library (SWL) Software License Agreement",
-      "licenseId": "SWL",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/SWL"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Saxpath.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Saxpath.json",
-      "referenceNumber": "32",
+      "detailsUrl": "https://spdx.org/licenses/Saxpath.json",
+      "referenceNumber": 390,
       "name": "Saxpath License",
       "licenseId": "Saxpath",
       "seeAlso": [
@@ -4127,10 +7354,32 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./Sendmail.html",
+      "reference": "https://spdx.org/licenses/SCEA.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Sendmail.json",
-      "referenceNumber": "283",
+      "detailsUrl": "https://spdx.org/licenses/SCEA.json",
+      "referenceNumber": 484,
+      "name": "SCEA Shared Source License",
+      "licenseId": "SCEA",
+      "seeAlso": [
+        "http://research.scea.com/scea_shared_source_license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SchemeReport.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SchemeReport.json",
+      "referenceNumber": 91,
+      "name": "Scheme Language Report License",
+      "licenseId": "SchemeReport",
+      "seeAlso": [],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Sendmail.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Sendmail.json",
+      "referenceNumber": 266,
       "name": "Sendmail License",
       "licenseId": "Sendmail",
       "seeAlso": [
@@ -4140,10 +7389,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./Sendmail-8.23.html",
+      "reference": "https://spdx.org/licenses/Sendmail-8.23.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Sendmail-8.23.json",
-      "referenceNumber": "170",
+      "detailsUrl": "https://spdx.org/licenses/Sendmail-8.23.json",
+      "referenceNumber": 55,
       "name": "Sendmail License 8.23",
       "licenseId": "Sendmail-8.23",
       "seeAlso": [
@@ -4153,10 +7402,107 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./SimPL-2.0.html",
+      "reference": "https://spdx.org/licenses/Sendmail-Open-Source-1.1.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/SimPL-2.0.json",
-      "referenceNumber": "241",
+      "detailsUrl": "https://spdx.org/licenses/Sendmail-Open-Source-1.1.json",
+      "referenceNumber": 620,
+      "name": "Sendmail Open Source License v1.1",
+      "licenseId": "Sendmail-Open-Source-1.1",
+      "seeAlso": [
+        "https://github.com/trusteddomainproject/OpenDMARC/blob/master/LICENSE.Sendmail"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SGI-B-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SGI-B-1.0.json",
+      "referenceNumber": 56,
+      "name": "SGI Free Software License B v1.0",
+      "licenseId": "SGI-B-1.0",
+      "seeAlso": [
+        "http://oss.sgi.com/projects/FreeB/SGIFreeSWLicB.1.0.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SGI-B-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SGI-B-1.1.json",
+      "referenceNumber": 296,
+      "name": "SGI Free Software License B v1.1",
+      "licenseId": "SGI-B-1.1",
+      "seeAlso": [
+        "http://oss.sgi.com/projects/FreeB/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SGI-B-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SGI-B-2.0.json",
+      "referenceNumber": 617,
+      "name": "SGI Free Software License B v2.0",
+      "licenseId": "SGI-B-2.0",
+      "seeAlso": [
+        "http://oss.sgi.com/projects/FreeB/SGIFreeSWLicB.2.0.pdf"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/SGI-OpenGL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SGI-OpenGL.json",
+      "referenceNumber": 34,
+      "name": "SGI OpenGL License",
+      "licenseId": "SGI-OpenGL",
+      "seeAlso": [
+        "https://gitlab.freedesktop.org/mesa/glw/-/blob/master/README?ref_type\u003dheads"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SGP4.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SGP4.json",
+      "referenceNumber": 572,
+      "name": "SGP4 Permission Notice",
+      "licenseId": "SGP4",
+      "seeAlso": [
+        "https://celestrak.org/publications/AIAA/2006-6753/faq.php"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SHL-0.5.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SHL-0.5.json",
+      "referenceNumber": 267,
+      "name": "Solderpad Hardware License v0.5",
+      "licenseId": "SHL-0.5",
+      "seeAlso": [
+        "https://solderpad.org/licenses/SHL-0.5/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SHL-0.51.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SHL-0.51.json",
+      "referenceNumber": 582,
+      "name": "Solderpad Hardware License, Version 0.51",
+      "licenseId": "SHL-0.51",
+      "seeAlso": [
+        "https://solderpad.org/licenses/SHL-0.51/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SimPL-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SimPL-2.0.json",
+      "referenceNumber": 452,
       "name": "Simple Public License 2.0",
       "licenseId": "SimPL-2.0",
       "seeAlso": [
@@ -4165,23 +7511,159 @@
       "isOsiApproved": true
     },
     {
-      "reference": "./Sleepycat.html",
+      "reference": "https://spdx.org/licenses/SISSL.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Sleepycat.json",
-      "referenceNumber": "53",
+      "detailsUrl": "https://spdx.org/licenses/SISSL.json",
+      "referenceNumber": 110,
+      "name": "Sun Industry Standards Source License v1.1",
+      "licenseId": "SISSL",
+      "seeAlso": [
+        "http://www.openoffice.org/licenses/sissl_license.html",
+        "https://opensource.org/licenses/SISSL"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/SISSL-1.2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SISSL-1.2.json",
+      "referenceNumber": 253,
+      "name": "Sun Industry Standards Source License v1.2",
+      "licenseId": "SISSL-1.2",
+      "seeAlso": [
+        "http://gridscheduler.sourceforge.net/Gridengine_SISSL_license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SL.json",
+      "referenceNumber": 83,
+      "name": "SL License",
+      "licenseId": "SL",
+      "seeAlso": [
+        "https://github.com/mtoyoda/sl/blob/master/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Sleepycat.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Sleepycat.json",
+      "referenceNumber": 42,
       "name": "Sleepycat License",
       "licenseId": "Sleepycat",
       "seeAlso": [
         "https://opensource.org/licenses/Sleepycat"
       ],
-      "isOsiApproved": true
+      "isOsiApproved": true,
+      "isFsfLibre": true
     },
     {
-      "reference": "./Spencer-86.html",
+      "reference": "https://spdx.org/licenses/SMAIL-GPL.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Spencer-86.json",
-      "referenceNumber": "178",
+      "detailsUrl": "https://spdx.org/licenses/SMAIL-GPL.json",
+      "referenceNumber": 546,
+      "name": "SMAIL General Public License",
+      "licenseId": "SMAIL-GPL",
+      "seeAlso": [
+        "https://sources.debian.org/copyright/license/debianutils/4.11.2/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SMLNJ.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SMLNJ.json",
+      "referenceNumber": 81,
+      "name": "Standard ML of New Jersey License",
+      "licenseId": "SMLNJ",
+      "seeAlso": [
+        "https://www.smlnj.org/license.html"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/SMPPL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SMPPL.json",
+      "referenceNumber": 579,
+      "name": "Secure Messaging Protocol Public License",
+      "licenseId": "SMPPL",
+      "seeAlso": [
+        "https://github.com/dcblake/SMP/blob/master/Documentation/License.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SNIA.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SNIA.json",
+      "referenceNumber": 224,
+      "name": "SNIA Public License 1.1",
+      "licenseId": "SNIA",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/SNIA_Public_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/snprintf.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/snprintf.json",
+      "referenceNumber": 594,
+      "name": "snprintf License",
+      "licenseId": "snprintf",
+      "seeAlso": [
+        "https://github.com/openssh/openssh-portable/blob/master/openbsd-compat/bsd-snprintf.c#L2"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SOFA.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SOFA.json",
+      "referenceNumber": 375,
+      "name": "SOFA Software License",
+      "licenseId": "SOFA",
+      "seeAlso": [
+        "http://www.iausofa.org/tandc.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/softSurfer.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/softSurfer.json",
+      "referenceNumber": 593,
+      "name": "softSurfer License",
+      "licenseId": "softSurfer",
+      "seeAlso": [
+        "https://github.com/mm2/Little-CMS/blob/master/src/cmssm.c#L207",
+        "https://fedoraproject.org/wiki/Licensing/softSurfer"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Soundex.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Soundex.json",
+      "referenceNumber": 374,
+      "name": "Soundex License",
+      "licenseId": "Soundex",
+      "seeAlso": [
+        "https://metacpan.org/release/RJBS/Text-Soundex-3.05/source/Soundex.pm#L3-11"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Spencer-86.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Spencer-86.json",
+      "referenceNumber": 193,
       "name": "Spencer License 86",
       "licenseId": "Spencer-86",
       "seeAlso": [
@@ -4190,22 +7672,23 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./Spencer-94.html",
+      "reference": "https://spdx.org/licenses/Spencer-94.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Spencer-94.json",
-      "referenceNumber": "205",
+      "detailsUrl": "https://spdx.org/licenses/Spencer-94.json",
+      "referenceNumber": 451,
       "name": "Spencer License 94",
       "licenseId": "Spencer-94",
       "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Henry_Spencer_Reg-Ex_Library_License"
+        "https://fedoraproject.org/wiki/Licensing/Henry_Spencer_Reg-Ex_Library_License",
+        "https://metacpan.org/release/KNOK/File-MMagic-1.30/source/COPYING#L28"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./Spencer-99.html",
+      "reference": "https://spdx.org/licenses/Spencer-99.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Spencer-99.json",
-      "referenceNumber": "61",
+      "detailsUrl": "https://spdx.org/licenses/Spencer-99.json",
+      "referenceNumber": 220,
       "name": "Spencer License 99",
       "licenseId": "Spencer-99",
       "seeAlso": [
@@ -4214,23 +7697,98 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./StandardML-NJ.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/StandardML-NJ.json",
-      "referenceNumber": "275",
-      "name": "Standard ML of New Jersey License",
-      "licenseId": "StandardML-NJ",
+      "reference": "https://spdx.org/licenses/SPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SPL-1.0.json",
+      "referenceNumber": 342,
+      "name": "Sun Public License v1.0",
+      "licenseId": "SPL-1.0",
       "seeAlso": [
-        "http://www.smlnj.org//license.html"
+        "https://opensource.org/licenses/SPL-1.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/ssh-keyscan.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ssh-keyscan.json",
+      "referenceNumber": 537,
+      "name": "ssh-keyscan License",
+      "licenseId": "ssh-keyscan",
+      "seeAlso": [
+        "https://github.com/openssh/openssh-portable/blob/master/LICENCE#L82"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./SugarCRM-1.1.3.html",
+      "reference": "https://spdx.org/licenses/SSH-OpenSSH.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/SugarCRM-1.1.3.json",
-      "referenceNumber": "331",
+      "detailsUrl": "https://spdx.org/licenses/SSH-OpenSSH.json",
+      "referenceNumber": 463,
+      "name": "SSH OpenSSH license",
+      "licenseId": "SSH-OpenSSH",
+      "seeAlso": [
+        "https://github.com/openssh/openssh-portable/blob/1b11ea7c58cd5c59838b5fa574cd456d6047b2d4/LICENCE#L10"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SSH-short.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SSH-short.json",
+      "referenceNumber": 573,
+      "name": "SSH short notice",
+      "licenseId": "SSH-short",
+      "seeAlso": [
+        "https://github.com/openssh/openssh-portable/blob/1b11ea7c58cd5c59838b5fa574cd456d6047b2d4/pathnames.h",
+        "http://web.mit.edu/kolya/.f/root/athena.mit.edu/sipb.mit.edu/project/openssh/OldFiles/src/openssh-2.9.9p2/ssh-add.1",
+        "https://joinup.ec.europa.eu/svn/lesoll/trunk/italc/lib/src/dsa_key.cpp"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SSLeay-standalone.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SSLeay-standalone.json",
+      "referenceNumber": 96,
+      "name": "SSLeay License - standalone",
+      "licenseId": "SSLeay-standalone",
+      "seeAlso": [
+        "https://www.tq-group.com/filedownloads/files/software-license-conditions/OriginalSSLeay/OriginalSSLeay.pdf"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SSPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SSPL-1.0.json",
+      "referenceNumber": 664,
+      "name": "Server Side Public License, v 1",
+      "licenseId": "SSPL-1.0",
+      "seeAlso": [
+        "https://www.mongodb.com/licensing/server-side-public-license"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/StandardML-NJ.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/StandardML-NJ.json",
+      "referenceNumber": 501,
+      "name": "Standard ML of New Jersey License",
+      "licenseId": "StandardML-NJ",
+      "seeAlso": [
+        "https://www.smlnj.org/license.html"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/SugarCRM-1.1.3.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SugarCRM-1.1.3.json",
+      "referenceNumber": 222,
       "name": "SugarCRM Public License v1.1.3",
       "licenseId": "SugarCRM-1.1.3",
       "seeAlso": [
@@ -4239,10 +7797,95 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./TAPR-OHL-1.0.html",
+      "reference": "https://spdx.org/licenses/SUL-1.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/TAPR-OHL-1.0.json",
-      "referenceNumber": "9",
+      "detailsUrl": "https://spdx.org/licenses/SUL-1.0.json",
+      "referenceNumber": 557,
+      "name": "Sustainable Use License v1.0",
+      "licenseId": "SUL-1.0",
+      "seeAlso": [
+        "https://github.com/n8n-io/n8n/blob/master/LICENSE.md"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Sun-PPP.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Sun-PPP.json",
+      "referenceNumber": 39,
+      "name": "Sun PPP License",
+      "licenseId": "Sun-PPP",
+      "seeAlso": [
+        "https://github.com/ppp-project/ppp/blob/master/pppd/eap.c#L7-L16"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Sun-PPP-2000.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Sun-PPP-2000.json",
+      "referenceNumber": 70,
+      "name": "Sun PPP License (2000)",
+      "licenseId": "Sun-PPP-2000",
+      "seeAlso": [
+        "https://github.com/ppp-project/ppp/blob/master/modules/ppp_ahdlc.c#L7-L19"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SunPro.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SunPro.json",
+      "referenceNumber": 395,
+      "name": "SunPro License",
+      "licenseId": "SunPro",
+      "seeAlso": [
+        "https://github.com/freebsd/freebsd-src/blob/main/lib/msun/src/e_acosh.c",
+        "https://github.com/freebsd/freebsd-src/blob/main/lib/msun/src/e_lgammal.c"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/SWL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/SWL.json",
+      "referenceNumber": 196,
+      "name": "Scheme Widget Library (SWL) Software License Agreement",
+      "licenseId": "SWL",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/SWL"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/swrule.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/swrule.json",
+      "referenceNumber": 348,
+      "name": "swrule License",
+      "licenseId": "swrule",
+      "seeAlso": [
+        "https://ctan.math.utah.edu/ctan/tex-archive/macros/generic/misc/swrule.sty"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Symlinks.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Symlinks.json",
+      "referenceNumber": 517,
+      "name": "Symlinks License",
+      "licenseId": "Symlinks",
+      "seeAlso": [
+        "https://www.mail-archive.com/debian-bugs-rc@lists.debian.org/msg11494.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/TAPR-OHL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/TAPR-OHL-1.0.json",
+      "referenceNumber": 80,
       "name": "TAPR Open Hardware License v1.0",
       "licenseId": "TAPR-OHL-1.0",
       "seeAlso": [
@@ -4251,10 +7894,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./TCL.html",
+      "reference": "https://spdx.org/licenses/TCL.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/TCL.json",
-      "referenceNumber": "51",
+      "detailsUrl": "https://spdx.org/licenses/TCL.json",
+      "referenceNumber": 625,
       "name": "TCL/TK License",
       "licenseId": "TCL",
       "seeAlso": [
@@ -4264,10 +7907,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./TCP-wrappers.html",
+      "reference": "https://spdx.org/licenses/TCP-wrappers.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/TCP-wrappers.json",
-      "referenceNumber": "226",
+      "detailsUrl": "https://spdx.org/licenses/TCP-wrappers.json",
+      "referenceNumber": 278,
       "name": "TCP Wrappers License",
       "licenseId": "TCP-wrappers",
       "seeAlso": [
@@ -4276,10 +7919,59 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./TMate.html",
+      "reference": "https://spdx.org/licenses/TermReadKey.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/TMate.json",
-      "referenceNumber": "390",
+      "detailsUrl": "https://spdx.org/licenses/TermReadKey.json",
+      "referenceNumber": 619,
+      "name": "TermReadKey License",
+      "licenseId": "TermReadKey",
+      "seeAlso": [
+        "https://github.com/jonathanstowe/TermReadKey/blob/master/README#L9-L10"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/TGPPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/TGPPL-1.0.json",
+      "referenceNumber": 142,
+      "name": "Transitive Grace Period Public Licence 1.0",
+      "licenseId": "TGPPL-1.0",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/TGPPL",
+        "https://tahoe-lafs.org/trac/tahoe-lafs/browser/trunk/COPYING.TGPPL.rst"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/ThirdEye.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ThirdEye.json",
+      "referenceNumber": 403,
+      "name": "ThirdEye License",
+      "licenseId": "ThirdEye",
+      "seeAlso": [
+        "https://sourceware.org/cgit/binutils-gdb/tree/include/coff/symconst.h#n11"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/threeparttable.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/threeparttable.json",
+      "referenceNumber": 14,
+      "name": "threeparttable License",
+      "licenseId": "threeparttable",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Threeparttable"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/TMate.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/TMate.json",
+      "referenceNumber": 176,
       "name": "TMate Open Source License",
       "licenseId": "TMate",
       "seeAlso": [
@@ -4288,10 +7980,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./TORQUE-1.1.html",
+      "reference": "https://spdx.org/licenses/TORQUE-1.1.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/TORQUE-1.1.json",
-      "referenceNumber": "181",
+      "detailsUrl": "https://spdx.org/licenses/TORQUE-1.1.json",
+      "referenceNumber": 214,
       "name": "TORQUE v2.5+ Software License v1.1",
       "licenseId": "TORQUE-1.1",
       "seeAlso": [
@@ -4300,10 +7992,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./TOSL.html",
+      "reference": "https://spdx.org/licenses/TOSL.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/TOSL.json",
-      "referenceNumber": "242",
+      "detailsUrl": "https://spdx.org/licenses/TOSL.json",
+      "referenceNumber": 416,
       "name": "Trusster Open Source License",
       "licenseId": "TOSL",
       "seeAlso": [
@@ -4312,10 +8004,71 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./TU-Berlin-1.0.html",
+      "reference": "https://spdx.org/licenses/TPDL.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/TU-Berlin-1.0.json",
-      "referenceNumber": "360",
+      "detailsUrl": "https://spdx.org/licenses/TPDL.json",
+      "referenceNumber": 666,
+      "name": "Time::ParseDate License",
+      "licenseId": "TPDL",
+      "seeAlso": [
+        "https://metacpan.org/pod/Time::ParseDate#LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/TPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/TPL-1.0.json",
+      "referenceNumber": 540,
+      "name": "THOR Public License 1.0",
+      "licenseId": "TPL-1.0",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing:ThorPublicLicense"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/TrustedQSL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/TrustedQSL.json",
+      "referenceNumber": 37,
+      "name": "TrustedQSL License",
+      "licenseId": "TrustedQSL",
+      "seeAlso": [
+        "https://sourceforge.net/p/trustedqsl/tqsl/ci/master/tree/LICENSE.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/TTWL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/TTWL.json",
+      "referenceNumber": 598,
+      "name": "Text-Tabs+Wrap License",
+      "licenseId": "TTWL",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/TTWL",
+        "https://github.com/ap/Text-Tabs/blob/master/lib.modern/Text/Tabs.pm#L148"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/TTYP0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/TTYP0.json",
+      "referenceNumber": 236,
+      "name": "TTYP0 License",
+      "licenseId": "TTYP0",
+      "seeAlso": [
+        "https://people.mpi-inf.mpg.de/~uwe/misc/uw-ttyp0/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/TU-Berlin-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/TU-Berlin-1.0.json",
+      "referenceNumber": 106,
       "name": "Technische Universitaet Berlin License 1.0",
       "licenseId": "TU-Berlin-1.0",
       "seeAlso": [
@@ -4324,10 +8077,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./TU-Berlin-2.0.html",
+      "reference": "https://spdx.org/licenses/TU-Berlin-2.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/TU-Berlin-2.0.json",
-      "referenceNumber": "380",
+      "detailsUrl": "https://spdx.org/licenses/TU-Berlin-2.0.json",
+      "referenceNumber": 669,
       "name": "Technische Universitaet Berlin License 2.0",
       "licenseId": "TU-Berlin-2.0",
       "seeAlso": [
@@ -4336,10 +8089,35 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./UCL-1.0.html",
+      "reference": "https://spdx.org/licenses/Ubuntu-font-1.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/UCL-1.0.json",
-      "referenceNumber": "281",
+      "detailsUrl": "https://spdx.org/licenses/Ubuntu-font-1.0.json",
+      "referenceNumber": 268,
+      "name": "Ubuntu Font Licence v1.0",
+      "licenseId": "Ubuntu-font-1.0",
+      "seeAlso": [
+        "https://ubuntu.com/legal/font-licence",
+        "https://assets.ubuntu.com/v1/81e5605d-ubuntu-font-licence-1.0.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/UCAR.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/UCAR.json",
+      "referenceNumber": 353,
+      "name": "UCAR License",
+      "licenseId": "UCAR",
+      "seeAlso": [
+        "https://github.com/Unidata/UDUNITS-2/blob/master/COPYRIGHT"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/UCL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/UCL-1.0.json",
+      "referenceNumber": 611,
       "name": "Upstream Compatibility License v1.0",
       "licenseId": "UCL-1.0",
       "seeAlso": [
@@ -4348,23 +8126,46 @@
       "isOsiApproved": true
     },
     {
-      "reference": "./UPL-1.0.html",
+      "reference": "https://spdx.org/licenses/ulem.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/UPL-1.0.json",
-      "referenceNumber": "138",
-      "name": "Universal Permissive License v1.0",
-      "licenseId": "UPL-1.0",
+      "detailsUrl": "https://spdx.org/licenses/ulem.json",
+      "referenceNumber": 514,
+      "name": "ulem License",
+      "licenseId": "ulem",
       "seeAlso": [
-        "https://opensource.org/licenses/UPL"
+        "https://mirrors.ctan.org/macros/latex/contrib/ulem/README"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/UMich-Merit.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/UMich-Merit.json",
+      "referenceNumber": 48,
+      "name": "Michigan/Merit Networks License",
+      "licenseId": "UMich-Merit",
+      "seeAlso": [
+        "https://github.com/radcli/radcli/blob/master/COPYRIGHT#L64"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Unicode-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Unicode-3.0.json",
+      "referenceNumber": 308,
+      "name": "Unicode License v3",
+      "licenseId": "Unicode-3.0",
+      "seeAlso": [
+        "https://www.unicode.org/license.txt"
       ],
       "isOsiApproved": true
     },
     {
-      "reference": "./Unicode-DFS-2015.html",
+      "reference": "https://spdx.org/licenses/Unicode-DFS-2015.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Unicode-DFS-2015.json",
-      "referenceNumber": "250",
+      "detailsUrl": "https://spdx.org/licenses/Unicode-DFS-2015.json",
+      "referenceNumber": 254,
       "name": "Unicode License Agreement - Data Files and Software (2015)",
       "licenseId": "Unicode-DFS-2015",
       "seeAlso": [
@@ -4373,47 +8174,127 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./Unicode-DFS-2016.html",
+      "reference": "https://spdx.org/licenses/Unicode-DFS-2016.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Unicode-DFS-2016.json",
-      "referenceNumber": "358",
+      "detailsUrl": "https://spdx.org/licenses/Unicode-DFS-2016.json",
+      "referenceNumber": 309,
       "name": "Unicode License Agreement - Data Files and Software (2016)",
       "licenseId": "Unicode-DFS-2016",
       "seeAlso": [
+        "https://www.unicode.org/license.txt",
+        "http://web.archive.org/web/20160823201924/http://www.unicode.org/copyright.html#License",
         "http://www.unicode.org/copyright.html"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": true
     },
     {
-      "reference": "./Unicode-TOU.html",
+      "reference": "https://spdx.org/licenses/Unicode-TOU.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Unicode-TOU.json",
-      "referenceNumber": "16",
+      "detailsUrl": "https://spdx.org/licenses/Unicode-TOU.json",
+      "referenceNumber": 115,
       "name": "Unicode Terms of Use",
       "licenseId": "Unicode-TOU",
       "seeAlso": [
+        "http://web.archive.org/web/20140704074106/http://www.unicode.org/copyright.html",
         "http://www.unicode.org/copyright.html"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./Unlicense.html",
+      "reference": "https://spdx.org/licenses/UnixCrypt.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Unlicense.json",
-      "referenceNumber": "167",
+      "detailsUrl": "https://spdx.org/licenses/UnixCrypt.json",
+      "referenceNumber": 180,
+      "name": "UnixCrypt License",
+      "licenseId": "UnixCrypt",
+      "seeAlso": [
+        "https://foss.heptapod.net/python-libs/passlib/-/blob/branch/stable/LICENSE#L70",
+        "https://opensource.apple.com/source/JBoss/JBoss-737/jboss-all/jetty/src/main/org/mortbay/util/UnixCrypt.java.auto.html",
+        "https://archive.eclipse.org/jetty/8.0.1.v20110908/xref/org/eclipse/jetty/http/security/UnixCrypt.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Unlicense.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Unlicense.json",
+      "referenceNumber": 337,
       "name": "The Unlicense",
       "licenseId": "Unlicense",
       "seeAlso": [
         "https://unlicense.org/"
       ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Unlicense-libtelnet.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Unlicense-libtelnet.json",
+      "referenceNumber": 113,
+      "name": "Unlicense - libtelnet variant",
+      "licenseId": "Unlicense-libtelnet",
+      "seeAlso": [
+        "https://github.com/seanmiddleditch/libtelnet/blob/develop/COPYING"
+      ],
       "isOsiApproved": false
     },
     {
-      "reference": "./VOSTROM.html",
+      "reference": "https://spdx.org/licenses/Unlicense-libwhirlpool.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/VOSTROM.json",
-      "referenceNumber": "340",
+      "detailsUrl": "https://spdx.org/licenses/Unlicense-libwhirlpool.json",
+      "referenceNumber": 565,
+      "name": "Unlicense - libwhirlpool variant",
+      "licenseId": "Unlicense-libwhirlpool",
+      "seeAlso": [
+        "https://github.com/dfateyev/libwhirlpool/blob/master/README#L27"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/UPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/UPL-1.0.json",
+      "referenceNumber": 88,
+      "name": "Universal Permissive License v1.0",
+      "licenseId": "UPL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/UPL"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/URT-RLE.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/URT-RLE.json",
+      "referenceNumber": 380,
+      "name": "Utah Raster Toolkit Run Length Encoded License",
+      "licenseId": "URT-RLE",
+      "seeAlso": [
+        "https://sourceforge.net/p/netpbm/code/HEAD/tree/super_stable/converter/other/pnmtorle.c",
+        "https://sourceforge.net/p/netpbm/code/HEAD/tree/super_stable/converter/other/rletopnm.c"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Vim.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Vim.json",
+      "referenceNumber": 327,
+      "name": "Vim License",
+      "licenseId": "Vim",
+      "seeAlso": [
+        "http://vimdoc.sourceforge.net/htmldoc/uganda.html"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/VOSTROM.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/VOSTROM.json",
+      "referenceNumber": 575,
       "name": "VOSTROM Public License for Open Source",
       "licenseId": "VOSTROM",
       "seeAlso": [
@@ -4422,10 +8303,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./VSL-1.0.html",
+      "reference": "https://spdx.org/licenses/VSL-1.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/VSL-1.0.json",
-      "referenceNumber": "378",
+      "detailsUrl": "https://spdx.org/licenses/VSL-1.0.json",
+      "referenceNumber": 562,
       "name": "Vovida Software License v1.0",
       "licenseId": "VSL-1.0",
       "seeAlso": [
@@ -4434,37 +8315,24 @@
       "isOsiApproved": true
     },
     {
-      "reference": "./Vim.html",
+      "reference": "https://spdx.org/licenses/W3C.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Vim.json",
-      "referenceNumber": "198",
-      "name": "Vim License",
-      "licenseId": "Vim",
-      "seeAlso": [
-        "http://vimdoc.sourceforge.net/htmldoc/uganda.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./W3C.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/W3C.json",
-      "referenceNumber": "101",
+      "detailsUrl": "https://spdx.org/licenses/W3C.json",
+      "referenceNumber": 479,
       "name": "W3C Software Notice and License (2002-12-31)",
       "licenseId": "W3C",
       "seeAlso": [
         "http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231.html",
         "https://opensource.org/licenses/W3C"
       ],
-      "isOsiApproved": true
+      "isOsiApproved": true,
+      "isFsfLibre": true
     },
     {
-      "reference": "./W3C-19980720.html",
+      "reference": "https://spdx.org/licenses/W3C-19980720.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/W3C-19980720.json",
-      "referenceNumber": "256",
+      "detailsUrl": "https://spdx.org/licenses/W3C-19980720.json",
+      "referenceNumber": 365,
       "name": "W3C Software Notice and License (1998-07-20)",
       "licenseId": "W3C-19980720",
       "seeAlso": [
@@ -4473,47 +8341,61 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./W3C-20150513.html",
+      "reference": "https://spdx.org/licenses/W3C-20150513.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/W3C-20150513.json",
-      "referenceNumber": "105",
+      "detailsUrl": "https://spdx.org/licenses/W3C-20150513.json",
+      "referenceNumber": 295,
       "name": "W3C Software Notice and Document License (2015-05-13)",
       "licenseId": "W3C-20150513",
       "seeAlso": [
-        "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"
+        "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document",
+        "https://www.w3.org/copyright/software-license-2015/",
+        "https://www.w3.org/copyright/software-license-2023/"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": true
     },
     {
-      "reference": "./WTFPL.html",
+      "reference": "https://spdx.org/licenses/w3m.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/WTFPL.json",
-      "referenceNumber": "19",
-      "name": "Do What The F*ck You Want To Public License",
-      "licenseId": "WTFPL",
+      "detailsUrl": "https://spdx.org/licenses/w3m.json",
+      "referenceNumber": 141,
+      "name": "w3m License",
+      "licenseId": "w3m",
       "seeAlso": [
-        "http://sam.zoy.org/wtfpl/COPYING"
+        "https://github.com/tats/w3m/blob/master/COPYING"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./Watcom-1.0.html",
+      "reference": "https://spdx.org/licenses/Watcom-1.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Watcom-1.0.json",
-      "referenceNumber": "135",
+      "detailsUrl": "https://spdx.org/licenses/Watcom-1.0.json",
+      "referenceNumber": 527,
       "name": "Sybase Open Watcom Public License 1.0",
       "licenseId": "Watcom-1.0",
       "seeAlso": [
         "https://opensource.org/licenses/Watcom-1.0"
       ],
-      "isOsiApproved": true
+      "isOsiApproved": true,
+      "isFsfLibre": false
     },
     {
-      "reference": "./Wsuipa.html",
+      "reference": "https://spdx.org/licenses/Widget-Workshop.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Wsuipa.json",
-      "referenceNumber": "246",
+      "detailsUrl": "https://spdx.org/licenses/Widget-Workshop.json",
+      "referenceNumber": 522,
+      "name": "Widget Workshop License",
+      "licenseId": "Widget-Workshop",
+      "seeAlso": [
+        "https://github.com/novnc/noVNC/blob/master/core/crypto/des.js#L24"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Wsuipa.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Wsuipa.json",
+      "referenceNumber": 564,
       "name": "Wsuipa License",
       "licenseId": "Wsuipa",
       "seeAlso": [
@@ -4522,48 +8404,97 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./X11.html",
+      "reference": "https://spdx.org/licenses/WTFPL.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/X11.json",
-      "referenceNumber": "93",
+      "detailsUrl": "https://spdx.org/licenses/WTFPL.json",
+      "referenceNumber": 418,
+      "name": "Do What The F*ck You Want To Public License",
+      "licenseId": "WTFPL",
+      "seeAlso": [
+        "http://www.wtfpl.net/about/",
+        "http://sam.zoy.org/wtfpl/COPYING"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/wwl.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/wwl.json",
+      "referenceNumber": 627,
+      "name": "WWL License",
+      "licenseId": "wwl",
+      "seeAlso": [
+        "http://www.db.net/downloads/wwl+db-1.3.tgz"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/wxWindows.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "https://spdx.org/licenses/wxWindows.json",
+      "referenceNumber": 431,
+      "name": "wxWindows Library License",
+      "licenseId": "wxWindows",
+      "seeAlso": [
+        "https://opensource.org/licenses/WXwindows"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/X11.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/X11.json",
+      "referenceNumber": 0,
       "name": "X11 License",
       "licenseId": "X11",
       "seeAlso": [
         "http://www.xfree86.org/3.3.6/COPYRIGHT2.html#3"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": false,
+      "isFsfLibre": true
     },
     {
-      "reference": "./XFree86-1.1.html",
+      "reference": "https://spdx.org/licenses/X11-distribute-modifications-variant.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/XFree86-1.1.json",
-      "referenceNumber": "149",
-      "name": "XFree86 License 1.1",
-      "licenseId": "XFree86-1.1",
+      "detailsUrl": "https://spdx.org/licenses/X11-distribute-modifications-variant.json",
+      "referenceNumber": 302,
+      "name": "X11 License Distribution Modification Variant",
+      "licenseId": "X11-distribute-modifications-variant",
       "seeAlso": [
-        "http://www.xfree86.org/current/LICENSE4.html"
+        "https://github.com/mirror/ncurses/blob/master/COPYING"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./XSkat.html",
+      "reference": "https://spdx.org/licenses/X11-swapped.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/XSkat.json",
-      "referenceNumber": "76",
-      "name": "XSkat License",
-      "licenseId": "XSkat",
+      "detailsUrl": "https://spdx.org/licenses/X11-swapped.json",
+      "referenceNumber": 248,
+      "name": "X11 swapped final paragraphs",
+      "licenseId": "X11-swapped",
       "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/XSkat_License"
+        "https://github.com/fedeinthemix/chez-srfi/blob/master/srfi/LICENSE"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./Xerox.html",
+      "reference": "https://spdx.org/licenses/Xdebug-1.03.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Xerox.json",
-      "referenceNumber": "216",
+      "detailsUrl": "https://spdx.org/licenses/Xdebug-1.03.json",
+      "referenceNumber": 109,
+      "name": "Xdebug License v 1.03",
+      "licenseId": "Xdebug-1.03",
+      "seeAlso": [
+        "https://github.com/xdebug/xdebug/blob/master/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Xerox.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Xerox.json",
+      "referenceNumber": 615,
       "name": "Xerox License",
       "licenseId": "Xerox",
       "seeAlso": [
@@ -4572,10 +8503,74 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./Xnet.html",
+      "reference": "https://spdx.org/licenses/Xfig.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Xnet.json",
-      "referenceNumber": "302",
+      "detailsUrl": "https://spdx.org/licenses/Xfig.json",
+      "referenceNumber": 125,
+      "name": "Xfig License",
+      "licenseId": "Xfig",
+      "seeAlso": [
+        "https://github.com/Distrotech/transfig/blob/master/transfig/transfig.c",
+        "https://fedoraproject.org/wiki/Licensing:MIT#Xfig_Variant",
+        "https://sourceforge.net/p/mcj/xfig/ci/master/tree/src/Makefile.am"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/XFree86-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/XFree86-1.1.json",
+      "referenceNumber": 646,
+      "name": "XFree86 License 1.1",
+      "licenseId": "XFree86-1.1",
+      "seeAlso": [
+        "http://www.xfree86.org/current/LICENSE4.html"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/xinetd.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/xinetd.json",
+      "referenceNumber": 93,
+      "name": "xinetd License",
+      "licenseId": "xinetd",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Xinetd_License"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/xkeyboard-config-Zinoviev.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/xkeyboard-config-Zinoviev.json",
+      "referenceNumber": 212,
+      "name": "xkeyboard-config Zinoviev License",
+      "licenseId": "xkeyboard-config-Zinoviev",
+      "seeAlso": [
+        "https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/blob/master/COPYING?ref_type\u003dheads#L178"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/xlock.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/xlock.json",
+      "referenceNumber": 362,
+      "name": "xlock License",
+      "licenseId": "xlock",
+      "seeAlso": [
+        "https://fossies.org/linux/tiff/contrib/ras/ras2tif.c"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Xnet.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Xnet.json",
+      "referenceNumber": 470,
       "name": "X.Net License",
       "licenseId": "Xnet",
       "seeAlso": [
@@ -4584,384 +8579,10 @@
       "isOsiApproved": true
     },
     {
-      "reference": "./YPL-1.0.html",
+      "reference": "https://spdx.org/licenses/xpp.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/YPL-1.0.json",
-      "referenceNumber": "282",
-      "name": "Yahoo! Public License v1.0",
-      "licenseId": "YPL-1.0",
-      "seeAlso": [
-        "http://www.zimbra.com/license/yahoo_public_license_1.0.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./YPL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/YPL-1.1.json",
-      "referenceNumber": "38",
-      "name": "Yahoo! Public License v1.1",
-      "licenseId": "YPL-1.1",
-      "seeAlso": [
-        "http://www.zimbra.com/license/yahoo_public_license_1.1.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./ZPL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/ZPL-1.1.json",
-      "referenceNumber": "80",
-      "name": "Zope Public License 1.1",
-      "licenseId": "ZPL-1.1",
-      "seeAlso": [
-        "http://old.zope.org/Resources/License/ZPL-1.1"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./ZPL-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/ZPL-2.0.json",
-      "referenceNumber": "106",
-      "name": "Zope Public License 2.0",
-      "licenseId": "ZPL-2.0",
-      "seeAlso": [
-        "http://old.zope.org/Resources/License/ZPL-2.0",
-        "https://opensource.org/licenses/ZPL-2.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./ZPL-2.1.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/ZPL-2.1.json",
-      "referenceNumber": "356",
-      "name": "Zope Public License 2.1",
-      "licenseId": "ZPL-2.1",
-      "seeAlso": [
-        "http://old.zope.org/Resources/ZPL/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Zed.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Zed.json",
-      "referenceNumber": "108",
-      "name": "Zed License",
-      "licenseId": "Zed",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Zed"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Zend-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Zend-2.0.json",
-      "referenceNumber": "361",
-      "name": "Zend License v2.0",
-      "licenseId": "Zend-2.0",
-      "seeAlso": [
-        "https://web.archive.org/web/20130517195954/http://www.zend.com/license/2_00.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Zimbra-1.3.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Zimbra-1.3.json",
-      "referenceNumber": "169",
-      "name": "Zimbra Public License v1.3",
-      "licenseId": "Zimbra-1.3",
-      "seeAlso": [
-        "http://web.archive.org/web/20100302225219/http://www.zimbra.com/license/zimbra-public-license-1-3.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Zimbra-1.4.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Zimbra-1.4.json",
-      "referenceNumber": "373",
-      "name": "Zimbra Public License v1.4",
-      "licenseId": "Zimbra-1.4",
-      "seeAlso": [
-        "http://www.zimbra.com/legal/zimbra-public-license-1-4"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Zlib.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Zlib.json",
-      "referenceNumber": "42",
-      "name": "zlib License",
-      "licenseId": "Zlib",
-      "seeAlso": [
-        "http://www.zlib.net/zlib_license.html",
-        "https://opensource.org/licenses/Zlib"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./blessing.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/blessing.json",
-      "referenceNumber": "290",
-      "name": "SQLite Blessing",
-      "licenseId": "blessing",
-      "seeAlso": [
-        "https://www.sqlite.org/src/artifact/e33a4df7e32d742a?ln\u003d4-9",
-        "https://sqlite.org/src/artifact/df5091916dbb40e6"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./bzip2-1.0.5.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/bzip2-1.0.5.json",
-      "referenceNumber": "179",
-      "name": "bzip2 and libbzip2 License v1.0.5",
-      "licenseId": "bzip2-1.0.5",
-      "seeAlso": [
-        "http://bzip.org/1.0.5/bzip2-manual-1.0.5.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./bzip2-1.0.6.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/bzip2-1.0.6.json",
-      "referenceNumber": "65",
-      "name": "bzip2 and libbzip2 License v1.0.6",
-      "licenseId": "bzip2-1.0.6",
-      "seeAlso": [
-        "https://github.com/asimonov-im/bzip2/blob/master/LICENSE"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./copyleft-next-0.3.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/copyleft-next-0.3.0.json",
-      "referenceNumber": "301",
-      "name": "copyleft-next 0.3.0",
-      "licenseId": "copyleft-next-0.3.0",
-      "seeAlso": [
-        "https://github.com/copyleft-next/copyleft-next/blob/master/Releases/copyleft-next-0.3.0"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./copyleft-next-0.3.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/copyleft-next-0.3.1.json",
-      "referenceNumber": "366",
-      "name": "copyleft-next 0.3.1",
-      "licenseId": "copyleft-next-0.3.1",
-      "seeAlso": [
-        "https://github.com/copyleft-next/copyleft-next/blob/master/Releases/copyleft-next-0.3.1"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./curl.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/curl.json",
-      "referenceNumber": "303",
-      "name": "curl License",
-      "licenseId": "curl",
-      "seeAlso": [
-        "https://github.com/bagder/curl/blob/master/COPYING"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./diffmark.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/diffmark.json",
-      "referenceNumber": "385",
-      "name": "diffmark license",
-      "licenseId": "diffmark",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/diffmark"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./dvipdfm.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/dvipdfm.json",
-      "referenceNumber": "18",
-      "name": "dvipdfm License",
-      "licenseId": "dvipdfm",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/dvipdfm"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./eCos-2.0.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/eCos-2.0.json",
-      "referenceNumber": "262",
-      "name": "eCos license version 2.0",
-      "licenseId": "eCos-2.0",
-      "seeAlso": [
-        "https://www.gnu.org/licenses/ecos-license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./eGenix.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/eGenix.json",
-      "referenceNumber": "206",
-      "name": "eGenix.com Public License 1.1.0",
-      "licenseId": "eGenix",
-      "seeAlso": [
-        "http://www.egenix.com/products/eGenix.com-Public-License-1.1.0.pdf",
-        "https://fedoraproject.org/wiki/Licensing/eGenix.com_Public_License_1.1.0"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./gSOAP-1.3b.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/gSOAP-1.3b.json",
-      "referenceNumber": "161",
-      "name": "gSOAP Public License v1.3b",
-      "licenseId": "gSOAP-1.3b",
-      "seeAlso": [
-        "http://www.cs.fsu.edu/~engelen/license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./gnuplot.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/gnuplot.json",
-      "referenceNumber": "371",
-      "name": "gnuplot License",
-      "licenseId": "gnuplot",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Gnuplot"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./iMatix.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/iMatix.json",
-      "referenceNumber": "171",
-      "name": "iMatix Standard Function Library Agreement",
-      "licenseId": "iMatix",
-      "seeAlso": [
-        "http://legacy.imatix.com/html/sfl/sfl4.htm#license"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./libpng-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/libpng-2.0.json",
-      "referenceNumber": "97",
-      "name": "PNG Reference Library version 2",
-      "licenseId": "libpng-2.0",
-      "seeAlso": [
-        "http://www.libpng.org/pub/png/src/libpng-LICENSE.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./libtiff.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/libtiff.json",
-      "referenceNumber": "395",
-      "name": "libtiff License",
-      "licenseId": "libtiff",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/libtiff"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./mpich2.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/mpich2.json",
-      "referenceNumber": "57",
-      "name": "mpich2 License",
-      "licenseId": "mpich2",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/MIT"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./psfrag.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/psfrag.json",
-      "referenceNumber": "396",
-      "name": "psfrag License",
-      "licenseId": "psfrag",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/psfrag"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./psutils.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/psutils.json",
-      "referenceNumber": "267",
-      "name": "psutils License",
-      "licenseId": "psutils",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/psutils"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./wxWindows.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "http://spdx.org/licenses/wxWindows.json",
-      "referenceNumber": "235",
-      "name": "wxWindows Library License",
-      "licenseId": "wxWindows",
-      "seeAlso": [
-        "https://opensource.org/licenses/WXwindows"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./xinetd.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/xinetd.json",
-      "referenceNumber": "387",
-      "name": "xinetd License",
-      "licenseId": "xinetd",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Xinetd_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./xpp.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/xpp.json",
-      "referenceNumber": "90",
+      "detailsUrl": "https://spdx.org/licenses/xpp.json",
+      "referenceNumber": 290,
       "name": "XPP License",
       "licenseId": "xpp",
       "seeAlso": [
@@ -4970,17 +8591,181 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./zlib-acknowledgement.html",
+      "reference": "https://spdx.org/licenses/XSkat.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/zlib-acknowledgement.json",
-      "referenceNumber": "237",
+      "detailsUrl": "https://spdx.org/licenses/XSkat.json",
+      "referenceNumber": 293,
+      "name": "XSkat License",
+      "licenseId": "XSkat",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/XSkat_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/xzoom.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/xzoom.json",
+      "referenceNumber": 90,
+      "name": "xzoom License",
+      "licenseId": "xzoom",
+      "seeAlso": [
+        "https://metadata.ftp-master.debian.org/changelogs//main/x/xzoom/xzoom_0.3-27_copyright"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/YPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/YPL-1.0.json",
+      "referenceNumber": 294,
+      "name": "Yahoo! Public License v1.0",
+      "licenseId": "YPL-1.0",
+      "seeAlso": [
+        "http://www.zimbra.com/license/yahoo_public_license_1.0.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/YPL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/YPL-1.1.json",
+      "referenceNumber": 481,
+      "name": "Yahoo! Public License v1.1",
+      "licenseId": "YPL-1.1",
+      "seeAlso": [
+        "http://www.zimbra.com/license/yahoo_public_license_1.1.html"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Zed.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Zed.json",
+      "referenceNumber": 189,
+      "name": "Zed License",
+      "licenseId": "Zed",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Zed"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Zeeff.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Zeeff.json",
+      "referenceNumber": 551,
+      "name": "Zeeff License",
+      "licenseId": "Zeeff",
+      "seeAlso": [
+        "ftp://ftp.tin.org/pub/news/utils/newsx/newsx-1.6.tar.gz"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Zend-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Zend-2.0.json",
+      "referenceNumber": 444,
+      "name": "Zend License v2.0",
+      "licenseId": "Zend-2.0",
+      "seeAlso": [
+        "https://web.archive.org/web/20130517195954/http://www.zend.com/license/2_00.txt"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Zimbra-1.3.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Zimbra-1.3.json",
+      "referenceNumber": 26,
+      "name": "Zimbra Public License v1.3",
+      "licenseId": "Zimbra-1.3",
+      "seeAlso": [
+        "http://web.archive.org/web/20100302225219/http://www.zimbra.com/license/zimbra-public-license-1-3.html"
+      ],
+      "isOsiApproved": false,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/Zimbra-1.4.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Zimbra-1.4.json",
+      "referenceNumber": 330,
+      "name": "Zimbra Public License v1.4",
+      "licenseId": "Zimbra-1.4",
+      "seeAlso": [
+        "http://www.zimbra.com/legal/zimbra-public-license-1-4"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/Zlib.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/Zlib.json",
+      "referenceNumber": 421,
+      "name": "zlib License",
+      "licenseId": "Zlib",
+      "seeAlso": [
+        "http://www.zlib.net/zlib_license.html",
+        "https://opensource.org/licenses/Zlib"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/zlib-acknowledgement.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/zlib-acknowledgement.json",
+      "referenceNumber": 188,
       "name": "zlib/libpng License with Acknowledgement",
       "licenseId": "zlib-acknowledgement",
       "seeAlso": [
         "https://fedoraproject.org/wiki/Licensing/ZlibWithAcknowledgement"
       ],
       "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/ZPL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ZPL-1.1.json",
+      "referenceNumber": 597,
+      "name": "Zope Public License 1.1",
+      "licenseId": "ZPL-1.1",
+      "seeAlso": [
+        "http://old.zope.org/Resources/License/ZPL-1.1"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "https://spdx.org/licenses/ZPL-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ZPL-2.0.json",
+      "referenceNumber": 555,
+      "name": "Zope Public License 2.0",
+      "licenseId": "ZPL-2.0",
+      "seeAlso": [
+        "http://old.zope.org/Resources/License/ZPL-2.0",
+        "https://opensource.org/licenses/ZPL-2.0"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
+    },
+    {
+      "reference": "https://spdx.org/licenses/ZPL-2.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ZPL-2.1.json",
+      "referenceNumber": 272,
+      "name": "Zope Public License 2.1",
+      "licenseId": "ZPL-2.1",
+      "seeAlso": [
+        "http://old.zope.org/Resources/ZPL/"
+      ],
+      "isOsiApproved": true,
+      "isFsfLibre": true
     }
   ],
-  "releaseDate": "2019-10-03"
+  "releaseDate": "2025-07-01T00:00:00Z"
 }


### PR DESCRIPTION
Update license list from version "3.6-13-g75eedc1" (circa 10 Jul 2019 ) to 3.27.0 (1 Jul 2025).

Use data from https://github.com/spdx/license-list-data/releases/tag/v3.27.0

Note that the diff is huge and difficult to check, so it is may be better for the repo maintainer to update this by themselves for security and accuracy reason (and discarding this PR).

The latest releases of the license in JSON and other formats can be obtained from:
https://github.com/spdx/license-list-data/releases/