### PR TITLE
Add "one URL per line" desc to relatedLink / softwareRequirements fields

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,7 +174,10 @@ See top-level LICENSE file for more information
                 <label for="relatedLink">Related links</label>
                 <br />
                 <textarea rows="4" cols="50"
-                    name="relatedLink" id="relatedLink"></textarea>
+                    name="relatedLink" id="relatedLink"
+                    placeholder="https://www.example.com"></textarea>
+                <span class="field-description" id="relatedLink_descr">URL(s), one URL per line</span>
+            </p>
         </fieldset>
 
         <fieldset id="fieldsetRuntime" class="leafFieldset">
@@ -206,6 +209,8 @@ See top-level LICENSE file for more information
                     placeholder=
 "https://www.python.org/downloads/release/python-3130/
 https://github.com/psf/requests"></textarea>
+                <span class="field-description" id="softwareRequirements_descr">URL(s), one URL per line</span>
+            </p>
         </fieldset>
 
         <fieldset id="fieldsetCurrentVersion" class="leafFieldset">
@@ -333,9 +338,9 @@ Bugfixes: that and this." ></textarea>
 
     </form>
     <form>
-      <input type="button" id="generateCodemetaV3" value="Generate codemeta.json v3.0" disabled
-             title="Creates a codemeta.json v3.0 file below, from the information provided above." />
-      <input type="button" id="generateCodemetaV2" value="Generate codemeta.json v2.0" disabled
+        <input type="button" id="generateCodemetaV3" value="Generate codemeta.json v3.0" disabled
+            title="Creates a codemeta.json v3.0 file below, from the information provided above." />
+        <input type="button" id="generateCodemetaV2" value="Generate codemeta.json v2.0" disabled
             title="Creates a codemeta.json v2.0 file below, from the information provided above." />
         <input type="button" id="resetForm" value="Reset form"
             title="Erases all fields." />


### PR DESCRIPTION
When user put multiple URLs in one line for Related Links, the generator will warn:

> Bug detected! The data you wrote is correct; but for some reason, it seems we generated an invalid codemeta.json.

Put a field description to guide the user.

It will look like this:

<img width="449" height="137" alt="Screenshot 2568-10-04 at 13 21 11" src="https://github.com/user-attachments/assets/9c477277-f25d-4cf4-9463-1773f05c8e47" />

<img width="449" height="136" alt="Screenshot 2568-10-04 at 13 21 18" src="https://github.com/user-attachments/assets/1e4581cb-1f97-42bb-9c04-527de9e19b15" />

Note that relatedLink and softwareRequirements have different behaviour when it comes to JSON data:

- relatedLink will still put the invalid URL (a string with multiple URLs) in the JSON
- softwareRequirements on the other hand will not allow the invalid URL and the field will be an empty list instead