### PR TITLE
http -> https

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@ See top-level LICENSE file for more information
 
                 <br />
                 <span class="field-description" id="identifier_descr">
-                    such as ISBNs, GTIN codes, UUIDs, etc. see <a href="https://schema.org/identifier">schema.org/identifier</a>
+                    such as ISBNs, GTIN codes, UUIDs, etc. see <a href="https://schema.org/identifier">https://schema.org/identifier</a>
                 </span>
             </p>
             <!-- TODO:define better

--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@ See top-level LICENSE file for more information
 
                 <br />
                 <span class="field-description" id="identifier_descr">
-                    such as ISBNs, GTIN codes, UUIDs, etc. see <a href="http://schema.org/identifier">http://schema.org/identifier</a>
+                    such as ISBNs, GTIN codes, UUIDs, etc. see <a href="https://schema.org/identifier">schema.org/identifier</a>
                 </span>
             </p>
             <!-- TODO:define better
@@ -302,7 +302,7 @@ Bugfixes: that and this." ></textarea>
 
                 <br />
                 <span class="field-description" id="developmentStatuses_descr">
-                    see <a href="http://www.repostatus.org">www.repostatus.org</a> for details
+                    see <a href="https://www.repostatus.org">www.repostatus.org</a> for details
                 </span>
             </p>
 
@@ -315,7 +315,7 @@ Bugfixes: that and this." ></textarea>
             <p title="Part of">
                 <label for="isPartOf">Is part of</label>
                 <input type="URL" name="isPartOf" id="isPartOf"
-                    placeholder="http://The.Bigger.Framework.org" />
+                    placeholder="https://The.Bigger.Framework.org" />
             </p>
         </fieldset>
 
@@ -374,7 +374,7 @@ Bugfixes: that and this." ></textarea>
         Do you want to improve this tool ?
         Check out the
         <a href="https://github.com/codemeta/codemeta-generator">
-            CodeMeta-generator repository</a>
+            CodeMeta Generator repository</a>
         <br />
         Join the
         <a href="https://github.com/codemeta/codemeta">CodeMeta community</a>


### PR DESCRIPTION
- Use https when the target website currently use (redirected to) https
- The.Bigger.Framework.org is fictitious so it can be either http or https
- The label for "CodeMeta Generator repository" can be either "CodeMeta Generator repository" or "codemeta-generator repository"