### PR TITLE
Remove codemeta:type

### DIFF
--- a/js/validation/things.js
+++ b/js/validation/things.js
@@ -12,7 +12,7 @@
 function getDocumentType(doc) {
     // TODO: check there is at most one.
     // FIXME: is the last variant allowed?
-    return doc["type"] || doc["@type"] || doc["codemeta:type"]
+    return doc["type"] || doc["@type"];
 }
 
 function getDocumentId(doc) {


### PR DESCRIPTION
Follow up of https://github.com/codemeta/codemeta-generator/pull/76#issuecomment-3377346116

`codemeta:type` does not appear anywhere else in the code.

