### PR TITLE
Add license field placeholder

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@ See top-level LICENSE file for more information
                 <label for="license">License(s)</label>
                 <input list="licenses" name="license" id="license"
                     aria-describedby="licenses_descr"
-                    placeholder="BSD-2-Clause" >
+                    placeholder="LGPL-3.0-or-later" >
 
                 <datalist id="licenses">
                 </datalist>


### PR DESCRIPTION
Pick "BSD-2-Clause" as the placeholder because its one of the licenses that is FSF Free/Libre and OSI Approved, a bit less mainstream but not too rare. Nothing scientific here.