### PR TITLE
Fix license in codemeta.json: AGPL-3.0-only -> AGPL-3.0-or-later

### DIFF
--- a/codemeta.json
+++ b/codemeta.json
@@ -1,7 +1,7 @@
 {
     "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
     "@type": "SoftwareSourceCode",
-    "license": "https://spdx.org/licenses/AGPL-3.0-only",
+    "license": "https://spdx.org/licenses/AGPL-3.0-or-later",
     "codeRepository": "https://github.com/codemeta/codemeta-generator",
     "dateCreated": "2019-10-02",
     "issueTracker": "https://github.com/codemeta/codemeta-generator/issues",

--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@ See top-level LICENSE file for more information
             "name": "Software Heritage",
             "url": "https://www.softwareheritage.org/"
         },
-        "license": "https://spdx.org/licenses/AGPL-3.0-only",
+        "license": "https://spdx.org/licenses/AGPL-3.0-or-later",
         "dateCreated": "2019-10-02",
         "softwareVersion": "3.0"
     }

--- a/package.json
+++ b/package.json
@@ -14,5 +14,5 @@
   "devDependencies": {
     "cypress": "^15.3.0"
   },
-  "license": "AGPL-3.0-only"
+  "license": "AGPL-3.0-or-later"
 }


### PR DESCRIPTION
Use source code headers as authoritative source, per https://github.com/codemeta/codemeta-generator/issues/79#issuecomment-3384934458

To fix #79 