### PR TITLE
Make inline and footer links open in a new tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,7 +122,7 @@ See top-level LICENSE file for more information
                 <!-- This datalist is to be filled automatically -->
 
                 <br />
-                <span class="field-description" id="licenses_descr">from <a href="https://spdx.org/licenses/">SPDX License List</a>; type or select from the list, one by one</span>
+                <span class="field-description" id="licenses_descr">from <a href="https://spdx.org/licenses/" target="_blank" rel="noopener noreferrer" title="Link to list opens in a new tab">SPDX License List</a>; type or select from the list, one by one</span>
                 <div id="selected-licenses">
                     <!-- This div is to be filled as the user selects licenses -->
                 </div>
@@ -139,7 +139,7 @@ See top-level LICENSE file for more information
 
                 <br />
                 <span class="field-description" id="identifier_descr">
-                    such as ISBNs, GTIN codes, UUIDs, etc. see <a href="https://schema.org/identifier">https://schema.org/identifier</a>
+                    such as ISBNs, GTIN codes, UUIDs, etc. see <a href="https://schema.org/identifier" target="_blank" rel="noopener noreferrer" title="Link to reference opens in a new tab">https://schema.org/identifier</a>
                 </span>
             </p>
             <!-- TODO:define better
@@ -344,7 +344,7 @@ Bugfixes: that and this." ></textarea>
 
                 <br />
                 <span class="field-description" id="developmentStatuses_descr">
-                    see <a href="https://www.repostatus.org">www.repostatus.org</a> for details
+                    see <a href="https://www.repostatus.org" target="_blank" rel="noopener noreferrer" title="Link to reference opens in a new tab">www.repostatus.org</a> for details
                 </span>
             </p>
 
@@ -419,22 +419,22 @@ Bugfixes: that and this." ></textarea>
     <p style="text-align:center;">
         Do you want to improve this tool ?
         Check out the
-        <a href="https://github.com/codemeta/codemeta-generator">
+        <a href="https://github.com/codemeta/codemeta-generator" target="_blank" rel="noopener noreferrer" title="Link to repository opens in a new tab">
             CodeMeta Generator repository</a>
         <br />
         Join the
-        <a href="https://github.com/codemeta/codemeta">CodeMeta community</a>
+        <a href="https://github.com/codemeta/codemeta" target="_blank" rel="noopener noreferrer" title="Link to repository opens in a new tab">CodeMeta community</a>
         discussion
         <br />
         The CodeMeta vocabulary -
-        <a href="https://doi.org/10.5063/schema/codemeta-2.0">v2.0</a>
+        <a href="https://doi.org/10.5063/schema/codemeta-2.0" target="_blank" rel="noopener noreferrer" title="Link to reference opens in a new tab">v2.0</a>
         -
-        <a href="https://w3id.org/codemeta/3.0">v3.0</a>
+        <a href="https://w3id.org/codemeta/3.0" target="_blank" rel="noopener noreferrer" title="Link to reference opens in a new tab">v3.0</a>
     </p>
 
     <h2 style="text-align:right;">Contributed by</h2>
     <p style="text-align:right;">
-        <a href="https://www.softwareheritage.org/save-and-reference-research-software/">
+        <a href="https://www.softwareheritage.org/save-and-reference-research-software/" target="_blank" rel="noopener noreferrer" title="Link to site opens in a new tab">
             <img alt="Software Heritage" src="https://annex.softwareheritage.org/public/logo/software-heritage-logo-title-motto.svg"
                 width="300">
         </a>


### PR DESCRIPTION
When the generator is included in an iframe, such as requested in codemeta.github.io#84 and implemented in codemeta.github.io#89 clicking the links will attempt and fail to load in the iframe because of CORS which doesn't affect the generator due to deployment within the same domain.