### PR TITLE
ci: bump github actions versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,18 +25,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup npm cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: '~/.npm'
           key: ${{ runner.os }}-node-24-${{ hashFiles('**/package.json') }}
           restore-keys: |
             ${{ runner.os }}-node-24-
- 
+
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
 
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup npm cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: '~/.npm'
           key: ${{ runner.os }}-node-24-${{ hashFiles('**/package.json') }}
@@ -21,7 +21,7 @@ jobs:
             ${{ runner.os }}-node-24-
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
 


### PR DESCRIPTION
Hi there, this is my first PR to the project. Some of your GitHub Actions were outdated.

Also `actions/setup-node` supports caching natively:
https://github.com/actions/setup-node?tab=readme-ov-file#usage

No need for a custom step like "Setup npm cache". You want to make use of that as well? I can update this PR.