### PR TITLE
ci: use cache in actions/setup-node

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,18 +27,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup npm cache
-        uses: actions/cache@v5
-        with:
-          path: '~/.npm'
-          key: ${{ runner.os }}-node-24-${{ hashFiles('**/package.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-24-
-
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
           node-version: '24'
+          cache: npm
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,18 +12,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup npm cache
-        uses: actions/cache@v5
-        with:
-          path: '~/.npm'
-          key: ${{ runner.os }}-node-24-${{ hashFiles('**/package.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-24-
-
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
           node-version: '24'
+          cache: npm
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Proposed in #90.

This should work like before.